### PR TITLE
Add threshold_* configuration options.

### DIFF
--- a/aware-core/src/main/java/com/aware/Accelerometer.java
+++ b/aware-core/src/main/java/com/aware/Accelerometer.java
@@ -33,6 +33,7 @@ import com.aware.utils.Aware_Sensor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.lang.Math;
 
 /**
  * AWARE Accelerometer module
@@ -53,8 +54,12 @@ public class Accelerometer extends Aware_Sensor implements SensorEventListener {
     private static PowerManager.WakeLock wakeLock = null;
     private static String LABEL = "";
     private static int FIFO_SIZE = 0;
+    private static float LAST_VALUE_0 = 0;
+    private static float LAST_VALUE_1 = 0;
+    private static float LAST_VALUE_2 = 0;
 
     private static int FREQUENCY = -1;
+    private static double THRESHOLD = 0;
 
     /**
      * Broadcasted event: new accelerometer values
@@ -88,6 +93,19 @@ public class Accelerometer extends Aware_Sensor implements SensorEventListener {
 
     @Override
     public void onSensorChanged(SensorEvent event) {
+        // Apply threshold.  This applies to each axis independently.  We could
+        // alternatively use Euclidian distance.  If change of values is not
+        // enough, do nothing.
+        if (Math.abs(event.values[0] - LAST_VALUE_0 ) < THRESHOLD
+            && Math.abs(event.values[1] - LAST_VALUE_1) < THRESHOLD
+            && Math.abs(event.values[2] - LAST_VALUE_2) < THRESHOLD) {
+            return;
+        }
+        // Update last values with new values for the next round.
+        LAST_VALUE_0 = event.values[0];
+        LAST_VALUE_1 = event.values[1];
+        LAST_VALUE_2 = event.values[2];
+        // Proceed with saving as usual.
         ContentValues rowData = new ContentValues();
         rowData.put(Accelerometer_Data.DEVICE_ID, Aware.getSetting(getApplicationContext(), Aware_Preferences.DEVICE_ID));
         rowData.put(Accelerometer_Data.TIMESTAMP, System.currentTimeMillis());
@@ -247,12 +265,18 @@ public class Accelerometer extends Aware_Sensor implements SensorEventListener {
                     Aware.setSetting(this, Aware_Preferences.FREQUENCY_ACCELEROMETER, 200000);
                 }
 
-                if (FREQUENCY != Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_ACCELEROMETER))) {
+                if (Aware.getSetting(this, Aware_Preferences.THRESHOLD_ACCELEROMETER).length() == 0) {
+                    Aware.setSetting(this, Aware_Preferences.THRESHOLD_ACCELEROMETER, 0.0);
+                }
+
+                if (FREQUENCY != Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_ACCELEROMETER))
+                        || THRESHOLD != Double.parseDouble(Aware.getSetting(getApplicationContext(), Aware_Preferences.THRESHOLD_ACCELEROMETER))) {
                     sensorHandler.removeCallbacksAndMessages(null);
                     mSensorManager.unregisterListener(this, mAccelerometer);
                     mSensorManager.registerListener(this, mAccelerometer, Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_ACCELEROMETER)), FIFO_SIZE, sensorHandler);
 
                     FREQUENCY = Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_ACCELEROMETER));
+                    THRESHOLD = Double.parseDouble(Aware.getSetting(getApplicationContext(), Aware_Preferences.THRESHOLD_ACCELEROMETER));
                 }
 
                 if (Aware.DEBUG) Log.d(TAG, "Accelerometer service active: " + FREQUENCY + "ms");

--- a/aware-core/src/main/java/com/aware/Aware_Preferences.java
+++ b/aware-core/src/main/java/com/aware/Aware_Preferences.java
@@ -58,6 +58,12 @@ public class Aware_Preferences {
     public static final String FREQUENCY_ACCELEROMETER = "frequency_accelerometer";
 
     /**
+     * Accelerometer threshold (float).  Do not record consecutive points if
+     * change in value of all axes is less than this.
+     */
+    public static final String THRESHOLD_ACCELEROMETER = "threshold_accelerometer";
+
+    /**
      * Activate/deactivate application usage log (boolean)
      */
     public static final String STATUS_APPLICATIONS = "status_applications";
@@ -127,6 +133,12 @@ public class Aware_Preferences {
     public static final String FREQUENCY_GRAVITY = "frequency_gravity";
 
     /**
+     * Threshold (float).  Do not record consecutive points if
+     * change in value of all axes is less than this.
+     */
+    public static final String THRESHOLD_GRAVITY = "threshold_gravity";
+
+    /**
      * Activate/deactivate gyroscope log (boolean)
      */
     public static final String STATUS_GYROSCOPE = "status_gyroscope";
@@ -139,6 +151,12 @@ public class Aware_Preferences {
      * 200000 - normal (default)
      */
     public static final String FREQUENCY_GYROSCOPE = "frequency_gyroscope";
+
+    /**
+     * Threshold (float).  Do not record consecutive points if
+     * change in value of all axes is less than this.
+     */
+    public static final String THRESHOLD_GYROSCOPE = "threshold_gyroscope";
 
     /**
      * Activate/deactivate GPS location log (boolean)
@@ -190,6 +208,12 @@ public class Aware_Preferences {
     public static final String FREQUENCY_LIGHT = "frequency_light";
 
     /**
+     * Light threshold (float).  Do not record consecutive points if
+     * change in value is less than this.
+     */
+    public static final String THRESHOLD_LIGHT = "threshold_light";
+
+    /**
      * Activate/deactivate linear accelerometer log (boolean)
      */
     public static final String STATUS_LINEAR_ACCELEROMETER = "status_linear_accelerometer";
@@ -202,6 +226,13 @@ public class Aware_Preferences {
      * 200000 - normal (default)
      */
     public static final String FREQUENCY_LINEAR_ACCELEROMETER = "frequency_linear_accelerometer";
+
+
+    /**
+     * Linear accelerometer threshold (float).  Do not record consecutive points if
+     * change in value of all axes is less than this.
+     */
+    public static final String THRESHOLD_LINEAR_ACCELEROMETER = "threshold_linear_accelerometer";
 
     /**
      * Activate/deactivate network usage events (boolean)
@@ -233,6 +264,12 @@ public class Aware_Preferences {
     public static final String FREQUENCY_MAGNETOMETER = "frequency_magnetometer";
 
     /**
+     * Threshold (float).  Do not record consecutive points if
+     * change in value of all axes is less than this.
+     */
+    public static final String THRESHOLD_MAGNETOMETER = "threshold_magnetometer";
+
+    /**
      * Activate/deactivate barometer log (boolean)
      */
     public static final String STATUS_BAROMETER = "status_barometer";
@@ -245,6 +282,12 @@ public class Aware_Preferences {
      * 200000 - normal (default)
      */
     public static final String FREQUENCY_BAROMETER = "frequency_barometer";
+
+    /**
+     * Threshold (float).  Do not record consecutive points if
+     * change in value of all axes is less than this.
+     */
+    public static final String THRESHOLD_BAROMETER = "threshold_barometer";
 
     /**
      * Activate/deactivate processor log (boolean)
@@ -281,6 +324,12 @@ public class Aware_Preferences {
     public static final String FREQUENCY_PROXIMITY = "frequency_proximity";
 
     /**
+     * Threshold (float).  Do not record consecutive points if
+     * change in value of all axes is less than this.
+     */
+    public static final String THRESHOLD_PROXIMITY = "threshold_proximity";
+
+    /**
      * Activate/deactivate rotation log (boolean)
      */
     public static final String STATUS_ROTATION = "status_rotation";
@@ -293,6 +342,12 @@ public class Aware_Preferences {
      * 200000 - normal (default)
      */
     public static final String FREQUENCY_ROTATION = "frequency_rotation";
+
+    /**
+     * Threshold (float).  Do not record consecutive points if
+     * change in value of all axes is less than this.
+     */
+    public static final String THRESHOLD_ROTATION = "threshold_rotation";
 
     /**
      * Activate/deactivate screen usage log (boolean)
@@ -312,6 +367,12 @@ public class Aware_Preferences {
      * 200000 - normal (default)
      */
     public static final String FREQUENCY_TEMPERATURE = "frequency_temperature";
+
+    /**
+     * Threshold (float).  Do not record consecutive points if
+     * change in value of all axes is less than this.
+     */
+    public static final String THRESHOLD_TEMPERATURE = "threshold_temperature";
 
     /**
      * Activate/deactivate telephony log (boolean)

--- a/aware-core/src/main/java/com/aware/Light.java
+++ b/aware-core/src/main/java/com/aware/Light.java
@@ -34,6 +34,7 @@ import com.aware.utils.Converters;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.lang.Math;
 
 /**
  * AWARE Light module
@@ -56,7 +57,9 @@ public class Light extends Aware_Sensor implements SensorEventListener {
     private static PowerManager powerManager = null;
     private static PowerManager.WakeLock wakeLock = null;
     private static int FIFO_SIZE = 0;
+    private static float LAST_VALUE_0 = 0;
     private static int FREQUENCY = -1;
+    private static double THRESHOLD = 0;
 
     /**
      * Broadcasted event: new light values
@@ -95,6 +98,13 @@ public class Light extends Aware_Sensor implements SensorEventListener {
 
     @Override
     public void onSensorChanged(SensorEvent event) {
+        // Apply threshold.  If change of values is not enough, do nothing.
+        if (Math.abs(event.values[0] - LAST_VALUE_0 ) < THRESHOLD) {
+            return;
+        }
+        // Update last values with new values for the next round.
+        LAST_VALUE_0 = event.values[0];
+        // Proceed with saving as usual.
         ContentValues rowData = new ContentValues();
         rowData.put(Light_Data.DEVICE_ID, Aware.getSetting(getApplicationContext(), Aware_Preferences.DEVICE_ID));
         rowData.put(Light_Data.TIMESTAMP, System.currentTimeMillis());
@@ -255,12 +265,18 @@ public class Light extends Aware_Sensor implements SensorEventListener {
                     Aware.setSetting(this, Aware_Preferences.FREQUENCY_LIGHT, 200000);
                 }
 
-                if (FREQUENCY != Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_LIGHT))) {
+                if (Aware.getSetting(this, Aware_Preferences.THRESHOLD_LIGHT).length() == 0) {
+                    Aware.setSetting(this, Aware_Preferences.THRESHOLD_LIGHT, 0.0);
+                }
+
+                if (FREQUENCY != Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_LIGHT))
+                        || THRESHOLD != Double.parseDouble(Aware.getSetting(getApplicationContext(), Aware_Preferences.THRESHOLD_LIGHT))) {
                     sensorHandler.removeCallbacksAndMessages(null);
                     mSensorManager.unregisterListener(this, mLight);
                     mSensorManager.registerListener(this, mLight, Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_LIGHT)), FIFO_SIZE, sensorHandler);
 
                     FREQUENCY = Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_LIGHT));
+                    THRESHOLD = Double.parseDouble(Aware.getSetting(getApplicationContext(), Aware_Preferences.THRESHOLD_LIGHT));
                 }
 
                 if (Aware.DEBUG) Log.d(TAG, "Light service active: " + FREQUENCY + "ms");

--- a/aware-core/src/main/java/com/aware/LinearAccelerometer.java
+++ b/aware-core/src/main/java/com/aware/LinearAccelerometer.java
@@ -34,6 +34,7 @@ import com.aware.utils.Converters;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.lang.Math;
 
 /**
  * AWARE Linear-accelerometer module:
@@ -58,7 +59,11 @@ public class LinearAccelerometer extends Aware_Sensor implements SensorEventList
     private static PowerManager powerManager = null;
     private static PowerManager.WakeLock wakeLock = null;
     private static int FIFO_SIZE = 0;
+    private static float LAST_VALUE_0 = 0;
+    private static float LAST_VALUE_1 = 0;
+    private static float LAST_VALUE_2 = 0;
     private static int FREQUENCY = -1;
+    private static double THRESHOLD = 0;
 
     /**
      * Broadcasted event: new sensor values
@@ -97,6 +102,19 @@ public class LinearAccelerometer extends Aware_Sensor implements SensorEventList
 
     @Override
     public void onSensorChanged(SensorEvent event) {
+        // Apply threshold.  This applies to each axis independently.  We could
+        // alternatively use Euclidian distance.  If change of values is not
+        // enough, do nothing.
+        if (Math.abs(event.values[0] - LAST_VALUE_0 ) < THRESHOLD
+                && Math.abs(event.values[1] - LAST_VALUE_1) < THRESHOLD
+                && Math.abs(event.values[2] - LAST_VALUE_2) < THRESHOLD) {
+            return;
+        }
+        // Update last values with new values for the next round.
+        LAST_VALUE_0 = event.values[0];
+        LAST_VALUE_1 = event.values[1];
+        LAST_VALUE_2 = event.values[2];
+        // Proceed with saving as usual.
         ContentValues rowData = new ContentValues();
         rowData.put(Linear_Accelerometer_Data.DEVICE_ID, Aware.getSetting(getApplicationContext(), Aware_Preferences.DEVICE_ID));
         rowData.put(Linear_Accelerometer_Data.TIMESTAMP, System.currentTimeMillis());
@@ -259,12 +277,18 @@ public class LinearAccelerometer extends Aware_Sensor implements SensorEventList
                     Aware.setSetting(this, Aware_Preferences.FREQUENCY_LINEAR_ACCELEROMETER, 200000);
                 }
 
-                if (FREQUENCY != Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_LINEAR_ACCELEROMETER))) {
+                if (Aware.getSetting(this, Aware_Preferences.THRESHOLD_LINEAR_ACCELEROMETER).length() == 0) {
+                    Aware.setSetting(this, Aware_Preferences.THRESHOLD_LINEAR_ACCELEROMETER, 0.0);
+                }
+
+                if (FREQUENCY != Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_LINEAR_ACCELEROMETER))
+                        || THRESHOLD != Double.parseDouble(Aware.getSetting(getApplicationContext(), Aware_Preferences.THRESHOLD_LINEAR_ACCELEROMETER))) {
                     sensorHandler.removeCallbacksAndMessages(null);
                     mSensorManager.unregisterListener(this, mLinearAccelerator);
                     mSensorManager.registerListener(this, mLinearAccelerator, Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_LINEAR_ACCELEROMETER)), FIFO_SIZE, sensorHandler);
 
                     FREQUENCY = Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_LINEAR_ACCELEROMETER));
+                    THRESHOLD = Double.parseDouble(Aware.getSetting(getApplicationContext(), Aware_Preferences.THRESHOLD_LINEAR_ACCELEROMETER));
                 }
 
                 if (Aware.DEBUG) Log.d(TAG, "Linear-accelerometer service active: " + FREQUENCY + "ms");

--- a/aware-core/src/main/java/com/aware/Magnetometer.java
+++ b/aware-core/src/main/java/com/aware/Magnetometer.java
@@ -32,6 +32,7 @@ import com.aware.utils.Aware_Sensor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.lang.Math;
 
 /**
  * AWARE Magnetometer module
@@ -54,7 +55,11 @@ public class Magnetometer extends Aware_Sensor implements SensorEventListener {
     private static PowerManager powerManager = null;
     private static PowerManager.WakeLock wakeLock = null;
     private static int FIFO_SIZE = 0;
+    private static float LAST_VALUE_0 = 0;
+    private static float LAST_VALUE_1 = 0;
+    private static float LAST_VALUE_2 = 0;
     private static int FREQUENCY = -1;
+    private static double THRESHOLD = 0;
 
     /**
      * Broadcasted event: new sensor values
@@ -93,6 +98,13 @@ public class Magnetometer extends Aware_Sensor implements SensorEventListener {
 
     @Override
     public void onSensorChanged(SensorEvent event) {
+        // Apply threshold.  If change of values is not enough, do nothing.
+        if (Math.abs(event.values[0] - LAST_VALUE_0 ) < THRESHOLD) {
+            return;
+        }
+        // Update last values with new values for the next round.
+        LAST_VALUE_0 = event.values[0];
+        // Proceed with saving as usual.
         ContentValues rowData = new ContentValues();
         rowData.put(Magnetometer_Data.DEVICE_ID, Aware.getSetting(getApplicationContext(), Aware_Preferences.DEVICE_ID));
         rowData.put(Magnetometer_Data.TIMESTAMP, System.currentTimeMillis());
@@ -253,12 +265,18 @@ public class Magnetometer extends Aware_Sensor implements SensorEventListener {
                     Aware.setSetting(this, Aware_Preferences.FREQUENCY_MAGNETOMETER, 200000);
                 }
 
-                if (FREQUENCY != Integer.parseInt(Aware.getSetting(this, Aware_Preferences.FREQUENCY_MAGNETOMETER))) {
+                if (Aware.getSetting(this, Aware_Preferences.THRESHOLD_MAGNETOMETER).length() == 0) {
+                    Aware.setSetting(this, Aware_Preferences.THRESHOLD_MAGNETOMETER, 0.0);
+                }
+
+                if (FREQUENCY != Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_MAGNETOMETER))
+                        || THRESHOLD != Double.parseDouble(Aware.getSetting(getApplicationContext(), Aware_Preferences.THRESHOLD_MAGNETOMETER))) {
                     sensorHandler.removeCallbacksAndMessages(null);
                     mSensorManager.unregisterListener(this, mMagnetometer);
                     mSensorManager.registerListener(this, mMagnetometer, Integer.parseInt(Aware.getSetting(this, Aware_Preferences.FREQUENCY_MAGNETOMETER)), FIFO_SIZE, sensorHandler);
 
                     FREQUENCY = Integer.parseInt(Aware.getSetting(this, Aware_Preferences.FREQUENCY_MAGNETOMETER));
+                    THRESHOLD = Double.parseDouble(Aware.getSetting(getApplicationContext(), Aware_Preferences.THRESHOLD_MAGNETOMETER));
                 }
                 if (Aware.DEBUG) Log.d(TAG, "Magnetometer service active...");
             }

--- a/aware-core/src/main/java/com/aware/Proximity.java
+++ b/aware-core/src/main/java/com/aware/Proximity.java
@@ -32,6 +32,7 @@ import com.aware.utils.Aware_Sensor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.lang.Math;
 
 /**
  * AWARE Proximity module
@@ -49,7 +50,9 @@ public class Proximity extends Aware_Sensor implements SensorEventListener {
     private static PowerManager powerManager = null;
     private static PowerManager.WakeLock wakeLock = null;
     private static int FIFO_SIZE = 0;
+    private static float LAST_VALUE_0 = 0;
     private static int FREQUENCY = -1;
+    private static double THRESHOLD = 0;
 
     /**
      * Broadcasted event: new sensor values
@@ -88,6 +91,13 @@ public class Proximity extends Aware_Sensor implements SensorEventListener {
 
     @Override
     public void onSensorChanged(SensorEvent event) {
+        // Apply threshold.  If change of values is not enough, do nothing.
+        if (Math.abs(event.values[0] - LAST_VALUE_0 ) < THRESHOLD) {
+            return;
+        }
+        // Update last values with new values for the next round.
+        LAST_VALUE_0 = event.values[0];
+        // Proceed with saving as usual.
         ContentValues rowData = new ContentValues();
         rowData.put(Proximity_Data.DEVICE_ID, Aware.getSetting(getApplicationContext(), Aware_Preferences.DEVICE_ID));
         rowData.put(Proximity_Data.TIMESTAMP, System.currentTimeMillis());
@@ -248,12 +258,18 @@ public class Proximity extends Aware_Sensor implements SensorEventListener {
                     Aware.setSetting(this, Aware_Preferences.FREQUENCY_PROXIMITY, 200000);
                 }
 
-                if (FREQUENCY != Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_PROXIMITY))) {
+                if (Aware.getSetting(this, Aware_Preferences.THRESHOLD_PROXIMITY).length() == 0) {
+                    Aware.setSetting(this, Aware_Preferences.THRESHOLD_PROXIMITY, 0.0);
+                }
+
+                if (FREQUENCY != Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_PROXIMITY))
+                        || THRESHOLD != Double.parseDouble(Aware.getSetting(getApplicationContext(), Aware_Preferences.THRESHOLD_PROXIMITY))) {
                     sensorHandler.removeCallbacksAndMessages(null);
                     mSensorManager.unregisterListener(this, mProximity);
                     mSensorManager.registerListener(this, mProximity, Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_PROXIMITY)), FIFO_SIZE, sensorHandler);
 
                     FREQUENCY = Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_PROXIMITY));
+                    THRESHOLD = Double.parseDouble(Aware.getSetting(getApplicationContext(), Aware_Preferences.THRESHOLD_PROXIMITY));
                 }
 
                 if (Aware.DEBUG) Log.d(TAG, "Proximity service active: " + FREQUENCY + "ms");

--- a/aware-core/src/main/java/com/aware/Rotation.java
+++ b/aware-core/src/main/java/com/aware/Rotation.java
@@ -32,6 +32,7 @@ import com.aware.utils.Aware_Sensor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.lang.Math;
 
 /**
  * AWARE Rotation module
@@ -54,7 +55,11 @@ public class Rotation extends Aware_Sensor implements SensorEventListener {
     private static PowerManager powerManager = null;
     private static PowerManager.WakeLock wakeLock = null;
     private static int FIFO_SIZE = 0;
+    private static float LAST_VALUE_0 = 0;
+    private static float LAST_VALUE_1 = 0;
+    private static float LAST_VALUE_2 = 0;
     private static int FREQUENCY = -1;
+    private static double THRESHOLD = 0;
 
     /**
      * Broadcasted event: new rotation values
@@ -93,6 +98,19 @@ public class Rotation extends Aware_Sensor implements SensorEventListener {
 
     @Override
     public void onSensorChanged(SensorEvent event) {
+        // Apply threshold.  This applies to each axis independently.  We could
+        // alternatively use Euclidian distance.  If change of values is not
+        // enough, do nothing.
+        if (Math.abs(event.values[0] - LAST_VALUE_0 ) < THRESHOLD
+                && Math.abs(event.values[1] - LAST_VALUE_1) < THRESHOLD
+                && Math.abs(event.values[2] - LAST_VALUE_2) < THRESHOLD) {
+            return;
+        }
+        // Update last values with new values for the next round.
+        LAST_VALUE_0 = event.values[0];
+        LAST_VALUE_1 = event.values[1];
+        LAST_VALUE_2 = event.values[2];
+        // Proceed with saving as usual.
         ContentValues rowData = new ContentValues();
         rowData.put(Rotation_Data.DEVICE_ID, Aware.getSetting(getApplicationContext(), Aware_Preferences.DEVICE_ID));
         rowData.put(Rotation_Data.TIMESTAMP, System.currentTimeMillis());
@@ -258,12 +276,18 @@ public class Rotation extends Aware_Sensor implements SensorEventListener {
                     Aware.setSetting(this, Aware_Preferences.FREQUENCY_ROTATION, 200000);
                 }
 
-                if (FREQUENCY != Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_ROTATION))) {
+                if (Aware.getSetting(this, Aware_Preferences.THRESHOLD_ROTATION).length() == 0) {
+                    Aware.setSetting(this, Aware_Preferences.THRESHOLD_ROTATION, 0.0);
+                }
+
+                if (FREQUENCY != Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_ROTATION))
+                        || THRESHOLD != Double.parseDouble(Aware.getSetting(getApplicationContext(), Aware_Preferences.THRESHOLD_ROTATION))) {
                     sensorHandler.removeCallbacksAndMessages(null);
                     mSensorManager.unregisterListener(this, mRotation);
                     mSensorManager.registerListener(this, mRotation, Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_ROTATION)), FIFO_SIZE, sensorHandler);
 
                     FREQUENCY = Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_ROTATION));
+                    THRESHOLD = Double.parseDouble(Aware.getSetting(getApplicationContext(), Aware_Preferences.THRESHOLD_ROTATION));
                 }
 
                 if (Aware.DEBUG) Log.d(TAG, "Rotation service active...");

--- a/aware-core/src/main/java/com/aware/Temperature.java
+++ b/aware-core/src/main/java/com/aware/Temperature.java
@@ -34,6 +34,7 @@ import com.aware.utils.Converters;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.lang.Math;
 
 /**
  * AWARE Temperature module
@@ -56,7 +57,9 @@ public class Temperature extends Aware_Sensor implements SensorEventListener {
     private static PowerManager powerManager = null;
     private static PowerManager.WakeLock wakeLock = null;
     private static int FIFO_SIZE = 0;
+    private static float LAST_VALUE_0 = 0;
     private static int FREQUENCY = -1;
+    private static double THRESHOLD = 0;
 
     /**
      * Broadcasted event: new sensor values
@@ -95,6 +98,13 @@ public class Temperature extends Aware_Sensor implements SensorEventListener {
 
     @Override
     public void onSensorChanged(SensorEvent event) {
+        // Apply threshold.  If change of values is not enough, do nothing.
+        if (Math.abs(event.values[0] - LAST_VALUE_0 ) < THRESHOLD) {
+            return;
+        }
+        // Update last values with new values for the next round.
+        LAST_VALUE_0 = event.values[0];
+        // Proceed with saving as usual.
         ContentValues rowData = new ContentValues();
         rowData.put(Temperature_Data.DEVICE_ID, Aware.getSetting(getApplicationContext(), Aware_Preferences.DEVICE_ID));
         rowData.put(Temperature_Data.TIMESTAMP, System.currentTimeMillis());
@@ -255,12 +265,18 @@ public class Temperature extends Aware_Sensor implements SensorEventListener {
                     Aware.setSetting(this, Aware_Preferences.FREQUENCY_TEMPERATURE, 200000);
                 }
 
-                if (FREQUENCY != Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_TEMPERATURE))) {
+                if (Aware.getSetting(this, Aware_Preferences.THRESHOLD_TEMPERATURE).length() == 0) {
+                    Aware.setSetting(this, Aware_Preferences.THRESHOLD_TEMPERATURE, 0.0);
+                }
+
+                if (FREQUENCY != Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_TEMPERATURE))
+                        || THRESHOLD != Double.parseDouble(Aware.getSetting(getApplicationContext(), Aware_Preferences.THRESHOLD_TEMPERATURE))) {
                     sensorHandler.removeCallbacksAndMessages(null);
                     mSensorManager.unregisterListener(this, mTemperature);
                     mSensorManager.registerListener(this, mTemperature, Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_TEMPERATURE)), FIFO_SIZE, sensorHandler);
 
                     FREQUENCY = Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_TEMPERATURE));
+                    THRESHOLD = Double.parseDouble(Aware.getSetting(getApplicationContext(), Aware_Preferences.THRESHOLD_TEMPERATURE));
                 }
 
                 if (Aware.DEBUG) Log.d(TAG, "Temperature service active...");

--- a/aware-core/src/main/res/xml/aware_preferences.xml
+++ b/aware-core/src/main/res/xml/aware_preferences.xml
@@ -73,6 +73,14 @@
                 android:key="frequency_accelerometer"
                 android:persistent="true"
                 android:title="Sampling rate" />
+
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_accelerometer"
+                android:inputType="numberDecimal"
+                android:key="threshold_accelerometer"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
         </PreferenceScreen>
         <PreferenceScreen
             android:key="applications"
@@ -144,6 +152,14 @@
                 android:key="frequency_barometer"
                 android:persistent="true"
                 android:title="Sampling rate" />
+
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_barometer"
+                android:inputType="numberDecimal"
+                android:key="threshold_barometer"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
         </PreferenceScreen>
         <PreferenceScreen
             android:key="battery"
@@ -246,6 +262,14 @@
                 android:persistent="true"
                 android:title="Sampling rate" />
 
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_gravity"
+                android:inputType="numberDecimal"
+                android:key="threshold_gravity"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
+
         </PreferenceScreen>
         <PreferenceScreen
             android:key="gyroscope"
@@ -267,6 +291,14 @@
                 android:key="frequency_gyroscope"
                 android:persistent="true"
                 android:title="Sampling rate" />
+
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_gyroscope"
+                android:inputType="numberDecimal"
+                android:key="threshold_gyroscope"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
 
         </PreferenceScreen>
         <PreferenceScreen
@@ -352,6 +384,14 @@
                 android:persistent="true"
                 android:title="Sampling rate" />
 
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_light"
+                android:inputType="numberDecimal"
+                android:key="threshold_light"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
+
         </PreferenceScreen>
         <PreferenceScreen
             android:key="linear_accelerometer"
@@ -373,6 +413,14 @@
                 android:key="frequency_linear_accelerometer"
                 android:persistent="true"
                 android:title="Sampling rate" />
+
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_linear_accelerometer"
+                android:inputType="numberDecimal"
+                android:key="threshold_linear_accelerometer"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
 
         </PreferenceScreen>
         <PreferenceScreen
@@ -422,6 +470,14 @@
                 android:key="frequency_magnetometer"
                 android:persistent="true"
                 android:title="Sampling rate" />
+
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_magnetometer"
+                android:inputType="numberDecimal"
+                android:key="threshold_magnetometer"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
 
         </PreferenceScreen>
         <PreferenceScreen
@@ -487,6 +543,14 @@
                 android:persistent="true"
                 android:title="Sampling rate" />
 
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_proximity"
+                android:inputType="numberDecimal"
+                android:key="threshold_proximity"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
+
         </PreferenceScreen>
         <PreferenceScreen
             android:key="rotation"
@@ -508,6 +572,14 @@
                 android:key="frequency_rotation"
                 android:persistent="true"
                 android:title="Sampling rate" />
+
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_rotation"
+                android:inputType="numberDecimal"
+                android:key="threshold_rotation"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
 
         </PreferenceScreen>
         <PreferenceScreen
@@ -544,6 +616,14 @@
                 android:key="frequency_temperature"
                 android:persistent="true"
                 android:title="Sampling rate" />
+
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_temperature"
+                android:inputType="numberDecimal"
+                android:key="threshold_temperature"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
 
         </PreferenceScreen>
         <PreferenceScreen

--- a/aware-phone/src/main/java/com/aware/phone/Aware_Client.java
+++ b/aware-phone/src/main/java/com/aware/phone/Aware_Client.java
@@ -348,6 +348,23 @@ public class Aware_Client extends Aware_Activity {
             }
         });
         if (Aware.isStudy(awareContext)) frequency_temperature.setSelectable(false);
+
+        final EditTextPreference threshold_temperature = (EditTextPreference) findPreference(Aware_Preferences.THRESHOLD_TEMPERATURE);
+        if (Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_TEMPERATURE).length() > 0) {
+            String threshold = Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_TEMPERATURE);
+            threshold_temperature.setSummary(threshold);
+        }
+        threshold_temperature.setDefaultValue(Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_TEMPERATURE));
+        threshold_temperature.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                Aware.setSetting(awareContext, Aware_Preferences.THRESHOLD_TEMPERATURE, (String) newValue);
+                threshold_temperature.setSummary((String) newValue);
+                Aware.startTemperature(awareContext);
+                return true;
+            }
+        });
+        if (Aware.isStudy(awareContext)) threshold_temperature.setSelectable(false);
     }
 
     /**
@@ -409,6 +426,23 @@ public class Aware_Client extends Aware_Activity {
             }
         });
         if (Aware.isStudy(awareContext)) frequency_accelerometer.setSelectable(false);
+
+        final EditTextPreference threshold_accelerometer = (EditTextPreference) findPreference(Aware_Preferences.THRESHOLD_ACCELEROMETER);
+        if (Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_ACCELEROMETER).length() > 0) {
+            String threshold = Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_ACCELEROMETER);
+            threshold_accelerometer.setSummary(threshold);
+        }
+        threshold_accelerometer.setDefaultValue(Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_ACCELEROMETER));
+        threshold_accelerometer.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                Aware.setSetting(awareContext, Aware_Preferences.THRESHOLD_ACCELEROMETER, (String) newValue);
+                threshold_accelerometer.setSummary((String) newValue);
+                Aware.startAccelerometer(awareContext);
+                return true;
+            }
+        });
+        if (Aware.isStudy(awareContext)) threshold_accelerometer.setSelectable(false);
     }
 
     /**
@@ -471,6 +505,23 @@ public class Aware_Client extends Aware_Activity {
             }
         });
         if (Aware.isStudy(awareContext)) frequency_linear_accelerometer.setSelectable(false);
+
+        final EditTextPreference threshold_linear_accelerometer = (EditTextPreference) findPreference(Aware_Preferences.THRESHOLD_LINEAR_ACCELEROMETER);
+        if (Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_LINEAR_ACCELEROMETER).length() > 0) {
+            String threshold = Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_LINEAR_ACCELEROMETER);
+            threshold_linear_accelerometer.setSummary(threshold);
+        }
+        threshold_linear_accelerometer.setDefaultValue(Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_LINEAR_ACCELEROMETER));
+        threshold_linear_accelerometer.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                Aware.setSetting(awareContext, Aware_Preferences.THRESHOLD_LINEAR_ACCELEROMETER, (String) newValue);
+                threshold_linear_accelerometer.setSummary((String) newValue);
+                Aware.startLinearAccelerometer(awareContext);
+                return true;
+            }
+        });
+        if (Aware.isStudy(awareContext)) threshold_linear_accelerometer.setSelectable(false);
     }
 
     /**
@@ -811,6 +862,23 @@ public class Aware_Client extends Aware_Activity {
             }
         });
         if (Aware.isStudy(awareContext)) frequency_gravity.setSelectable(false);
+
+        final EditTextPreference threshold_gravity = (EditTextPreference) findPreference(Aware_Preferences.THRESHOLD_GRAVITY);
+        if (Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_GRAVITY).length() > 0) {
+            String threshold = Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_GRAVITY);
+            threshold_gravity.setSummary(threshold);
+        }
+        threshold_gravity.setDefaultValue(Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_GRAVITY));
+        threshold_gravity.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                Aware.setSetting(awareContext, Aware_Preferences.THRESHOLD_GRAVITY, (String) newValue);
+                threshold_gravity.setSummary((String) newValue);
+                Aware.startGravity(awareContext);
+                return true;
+            }
+        });
+        if (Aware.isStudy(awareContext)) threshold_gravity.setSelectable(false);
     }
 
     /**
@@ -872,6 +940,23 @@ public class Aware_Client extends Aware_Activity {
             }
         });
         if (Aware.isStudy(awareContext)) frequency_gyroscope.setSelectable(false);
+
+        final EditTextPreference threshold_gyroscope = (EditTextPreference) findPreference(Aware_Preferences.THRESHOLD_GYROSCOPE);
+        if (Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_GYROSCOPE).length() > 0) {
+            String threshold = Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_GYROSCOPE);
+            threshold_gyroscope.setSummary(threshold);
+        }
+        threshold_gyroscope.setDefaultValue(Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_GYROSCOPE));
+        threshold_gyroscope.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                Aware.setSetting(awareContext, Aware_Preferences.THRESHOLD_GYROSCOPE, (String) newValue);
+                threshold_gyroscope.setSummary((String) newValue);
+                Aware.startGyroscope(awareContext);
+                return true;
+            }
+        });
+        if (Aware.isStudy(awareContext)) threshold_gyroscope.setSelectable(false);
     }
 
     /**
@@ -1319,6 +1404,23 @@ public class Aware_Client extends Aware_Activity {
             }
         });
         if (Aware.isStudy(awareContext)) frequency_light.setSelectable(false);
+
+        final EditTextPreference threshold_light = (EditTextPreference) findPreference(Aware_Preferences.THRESHOLD_LIGHT);
+        if (Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_LIGHT).length() > 0) {
+            String threshold = Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_LIGHT);
+            threshold_light.setSummary(threshold);
+        }
+        threshold_light.setDefaultValue(Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_LIGHT));
+        threshold_light.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                Aware.setSetting(awareContext, Aware_Preferences.THRESHOLD_LIGHT, (String) newValue);
+                threshold_light.setSummary((String) newValue);
+                Aware.startLight(awareContext);
+                return true;
+            }
+        });
+        if (Aware.isStudy(awareContext)) threshold_light.setSelectable(false);
     }
 
     /**
@@ -1381,6 +1483,23 @@ public class Aware_Client extends Aware_Activity {
             }
         });
         if (Aware.isStudy(awareContext)) frequency_magnetometer.setSelectable(false);
+
+        final EditTextPreference threshold_magnetometer = (EditTextPreference) findPreference(Aware_Preferences.THRESHOLD_MAGNETOMETER);
+        if (Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_MAGNETOMETER).length() > 0) {
+            String threshold = Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_MAGNETOMETER);
+            threshold_magnetometer.setSummary(threshold);
+        }
+        threshold_magnetometer.setDefaultValue(Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_MAGNETOMETER));
+        threshold_magnetometer.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                Aware.setSetting(awareContext, Aware_Preferences.THRESHOLD_MAGNETOMETER, (String) newValue);
+                threshold_magnetometer.setSummary((String) newValue);
+                Aware.startMagnetometer(awareContext);
+                return true;
+            }
+        });
+        if (Aware.isStudy(awareContext)) threshold_magnetometer.setSelectable(false);
     }
 
     /**
@@ -1443,6 +1562,23 @@ public class Aware_Client extends Aware_Activity {
             }
         });
         if (Aware.isStudy(awareContext)) frequency_pressure.setSelectable(false);
+
+        final EditTextPreference threshold_barometer = (EditTextPreference) findPreference(Aware_Preferences.THRESHOLD_BAROMETER);
+        if (Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_BAROMETER).length() > 0) {
+            String threshold = Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_BAROMETER);
+            threshold_barometer.setSummary(threshold);
+        }
+        threshold_barometer.setDefaultValue(Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_BAROMETER));
+        threshold_barometer.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                Aware.setSetting(awareContext, Aware_Preferences.THRESHOLD_BAROMETER, (String) newValue);
+                threshold_barometer.setSummary((String) newValue);
+                Aware.startBarometer(awareContext);
+                return true;
+            }
+        });
+        if (Aware.isStudy(awareContext)) threshold_barometer.setSelectable(false);
     }
 
     /**
@@ -1506,6 +1642,23 @@ public class Aware_Client extends Aware_Activity {
             }
         });
         if (Aware.isStudy(awareContext)) frequency_proximity.setSelectable(false);
+
+        final EditTextPreference threshold_proximity = (EditTextPreference) findPreference(Aware_Preferences.THRESHOLD_PROXIMITY);
+        if (Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_PROXIMITY).length() > 0) {
+            String threshold = Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_PROXIMITY);
+            threshold_proximity.setSummary(threshold);
+        }
+        threshold_proximity.setDefaultValue(Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_PROXIMITY));
+        threshold_proximity.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                Aware.setSetting(awareContext, Aware_Preferences.THRESHOLD_PROXIMITY, (String) newValue);
+                threshold_proximity.setSummary((String) newValue);
+                Aware.startProximity(awareContext);
+                return true;
+            }
+        });
+        if (Aware.isStudy(awareContext)) threshold_proximity.setSelectable(false);
     }
 
     /**
@@ -1568,6 +1721,23 @@ public class Aware_Client extends Aware_Activity {
             }
         });
         if (Aware.isStudy(awareContext)) frequency_rotation.setSelectable(false);
+
+        final EditTextPreference threshold_rotation = (EditTextPreference) findPreference(Aware_Preferences.THRESHOLD_ROTATION);
+        if (Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_ROTATION).length() > 0) {
+            String threshold = Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_ROTATION);
+            threshold_rotation.setSummary(threshold);
+        }
+        threshold_rotation.setDefaultValue(Aware.getSetting(awareContext, Aware_Preferences.THRESHOLD_ROTATION));
+        threshold_rotation.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                Aware.setSetting(awareContext, Aware_Preferences.THRESHOLD_ROTATION, (String) newValue);
+                threshold_rotation.setSummary((String) newValue);
+                Aware.startRotation(awareContext);
+                return true;
+            }
+        });
+        if (Aware.isStudy(awareContext)) threshold_rotation.setSelectable(false);
     }
 
     /**

--- a/aware-phone/src/main/res/xml/aware_preferences.xml
+++ b/aware-phone/src/main/res/xml/aware_preferences.xml
@@ -77,6 +77,14 @@
                 android:key="frequency_accelerometer"
                 android:persistent="true"
                 android:title="Sampling rate" />
+
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_accelerometer"
+                android:inputType="numberDecimal"
+                android:key="threshold_accelerometer"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
         </PreferenceScreen>
         <PreferenceScreen
             android:icon="@drawable/ic_action_applications"
@@ -156,6 +164,14 @@
                 android:key="frequency_barometer"
                 android:persistent="true"
                 android:title="Sampling rate" />
+
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_barometer"
+                android:inputType="numberDecimal"
+                android:key="threshold_barometer"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
         </PreferenceScreen>
         <PreferenceScreen
             android:icon="@drawable/ic_action_battery"
@@ -279,6 +295,14 @@
                 android:persistent="true"
                 android:title="Sampling rate" />
 
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_gravity"
+                android:inputType="numberDecimal"
+                android:key="threshold_gravity"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
+
         </PreferenceScreen>
         <PreferenceScreen
             android:icon="@drawable/ic_action_gyroscope"
@@ -304,6 +328,14 @@
                 android:key="frequency_gyroscope"
                 android:persistent="true"
                 android:title="Sampling rate" />
+
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_gyroscope"
+                android:inputType="numberDecimal"
+                android:key="threshold_gyroscope"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
 
         </PreferenceScreen>
         <PreferenceScreen
@@ -397,6 +429,14 @@
                 android:persistent="true"
                 android:title="Sampling rate" />
 
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_light"
+                android:inputType="numberDecimal"
+                android:key="threshold_light"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
+
         </PreferenceScreen>
         <PreferenceScreen
             android:icon="@drawable/ic_action_linear_acceleration"
@@ -422,6 +462,14 @@
                 android:key="frequency_linear_accelerometer"
                 android:persistent="true"
                 android:title="Sampling rate" />
+
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_linear_accelerometer"
+                android:inputType="numberDecimal"
+                android:key="threshold_linear_accelerometer"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
 
         </PreferenceScreen>
         <PreferenceScreen
@@ -479,6 +527,14 @@
                 android:key="frequency_magnetometer"
                 android:persistent="true"
                 android:title="Sampling rate" />
+
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_magnetometer"
+                android:inputType="numberDecimal"
+                android:key="threshold_magnetometer"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
 
         </PreferenceScreen>
         <PreferenceScreen
@@ -556,6 +612,14 @@
                 android:persistent="true"
                 android:title="Sampling rate" />
 
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_proximity"
+                android:inputType="numberDecimal"
+                android:key="threshold_proximity"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
+
         </PreferenceScreen>
         <PreferenceScreen
             android:icon="@drawable/ic_action_rotation"
@@ -581,6 +645,14 @@
                 android:key="frequency_rotation"
                 android:persistent="true"
                 android:title="Sampling rate" />
+
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_rotation"
+                android:inputType="numberDecimal"
+                android:key="threshold_rotation"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
 
         </PreferenceScreen>
         <PreferenceScreen
@@ -625,6 +697,14 @@
                 android:key="frequency_temperature"
                 android:persistent="true"
                 android:title="Sampling rate" />
+
+            <EditTextPreference
+                android:defaultValue="0"
+                android:dependency="status_temperature"
+                android:inputType="numberDecimal"
+                android:key="threshold_temperature"
+                android:persistent="true"
+                android:title="Threshold for recording changes" />
 
         </PreferenceScreen>
         <PreferenceScreen


### PR DESCRIPTION
As discussed in denzilferreira/aware-client#30.  Only baseline testing on
my device, could use more.

- This avoids recording successive points if the values have not
  changed much.  This allows high frequency sampling while also not
  generating ridiculous amounts of data (for example when the phone is
  not actively moving, for accelerometer).
- The option is present in the UI but there are no default choices to
  pick from.  Default value is zero, which should be previous
  behavior.
- Option name: threshold_accelerometer, etc.
- For all high-frequency sensors.