### PR TITLE
Improve hashing: specify hash functions and salts.

### DIFF
--- a/aware-core/src/main/java/com/aware/Applications.java
+++ b/aware-core/src/main/java/com/aware/Applications.java
@@ -133,7 +133,7 @@ public class Applications extends AccessibilityService {
                 rowData.put(Applications_Notifications.TIMESTAMP, System.currentTimeMillis());
                 rowData.put(Applications_Notifications.PACKAGE_NAME, event.getPackageName().toString());
                 rowData.put(Applications_Notifications.APPLICATION_NAME, getApplicationName(event.getPackageName().toString()));
-                rowData.put(Applications_Notifications.TEXT, Encrypter.hashSHA1(event.getText().toString()));
+                rowData.put(Applications_Notifications.TEXT, Encrypter.hash(getApplicationContext(), event.getText().toString()));
                 rowData.put(Applications_Notifications.SOUND, ((notificationDetails.sound != null) ? notificationDetails.sound.toString() : ""));
                 rowData.put(Applications_Notifications.VIBRATE, ((notificationDetails.vibrate != null) ? notificationDetails.vibrate.toString() : ""));
                 rowData.put(Applications_Notifications.DEFAULTS, notificationDetails.defaults);

--- a/aware-core/src/main/java/com/aware/Aware_Preferences.java
+++ b/aware-core/src/main/java/com/aware/Aware_Preferences.java
@@ -417,4 +417,19 @@ public class Aware_Preferences {
      * Activate/deactivate keyboard logging
      */
     public static final String STATUS_KEYBOARD = "status_keyboard";
+
+    /**
+     * Preferred hash function
+     */
+    public static final String HASH_FUNCTION = "hash_function";
+
+    /**
+     * hash function salt
+     */
+    public static final String HASH_SALT = "hash_salt";
+
+    /**
+     * hash function salt.  If "device_id", then salt with this device's device_id.
+     */
+    public static final String HASH_FUNCTION_PHONE = "hash_function_phone";
 }

--- a/aware-core/src/main/java/com/aware/Communication.java
+++ b/aware-core/src/main/java/com/aware/Communication.java
@@ -120,7 +120,7 @@ public class Communication extends Aware_Sensor {
                                 received.put(Calls_Data.DEVICE_ID, Aware.getSetting(getApplicationContext(), Aware_Preferences.DEVICE_ID));
                                 received.put(Calls_Data.TYPE, Calls.INCOMING_TYPE);
                                 received.put(Calls_Data.DURATION, lastCall.getInt(lastCall.getColumnIndex(Calls.DURATION)));
-                                received.put(Calls_Data.TRACE, Encrypter.hashSHA1( lastCall.getString(lastCall.getColumnIndex(Calls.NUMBER))) );
+                                received.put(Calls_Data.TRACE, Encrypter.hashPhone(getApplicationContext(), lastCall.getString(lastCall.getColumnIndex(Calls.NUMBER))) );
                                 
                                 try {
                                     getContentResolver().insert(Calls_Data.CONTENT_URI, received);
@@ -145,7 +145,7 @@ public class Communication extends Aware_Sensor {
                                 missed.put(Calls_Data.DEVICE_ID, Aware.getSetting(getApplicationContext(), Aware_Preferences.DEVICE_ID));
                                 missed.put(Calls_Data.TYPE, Calls.MISSED_TYPE);
                                 missed.put(Calls_Data.DURATION, lastCall.getInt(lastCall.getColumnIndex(Calls.DURATION)));
-                                missed.put(Calls_Data.TRACE, Encrypter.hashSHA1( lastCall.getString(lastCall.getColumnIndex(Calls.NUMBER))) );
+                                missed.put(Calls_Data.TRACE, Encrypter.hashPhone(getApplicationContext(), lastCall.getString(lastCall.getColumnIndex(Calls.NUMBER))) );
                                 try {
                                     getContentResolver().insert(Calls_Data.CONTENT_URI, missed);
                                 }catch( SQLiteException e ) {
@@ -168,7 +168,7 @@ public class Communication extends Aware_Sensor {
                                 outgoing.put(Calls_Data.DEVICE_ID, Aware.getSetting(getApplicationContext(), Aware_Preferences.DEVICE_ID));
                                 outgoing.put(Calls_Data.TYPE, Calls.OUTGOING_TYPE);
                                 outgoing.put(Calls_Data.DURATION, lastCall.getInt(lastCall.getColumnIndex(Calls.DURATION)));
-                                outgoing.put(Calls_Data.TRACE, Encrypter.hashSHA1( lastCall.getString(lastCall.getColumnIndex(Calls.NUMBER))) );
+                                outgoing.put(Calls_Data.TRACE, Encrypter.hashPhone(getApplicationContext(), lastCall.getString(lastCall.getColumnIndex(Calls.NUMBER))) );
                                 try {
                                     getContentResolver().insert(Calls_Data.CONTENT_URI, outgoing);
                                 }catch( SQLiteException e ) {
@@ -214,7 +214,7 @@ public class Communication extends Aware_Sensor {
                                 inbox.put(Messages_Data.TIMESTAMP, lastMessage.getLong(lastMessage.getColumnIndex("date")));
                                 inbox.put(Messages_Data.DEVICE_ID, Aware.getSetting(getApplicationContext(), Aware_Preferences.DEVICE_ID));
                                 inbox.put(Messages_Data.TYPE, MESSAGE_INBOX);
-                                inbox.put(Messages_Data.TRACE, Encrypter.hashSHA1(lastMessage.getString(lastMessage.getColumnIndex("address"))));
+                                inbox.put(Messages_Data.TRACE, Encrypter.hashPhone(getApplicationContext(), lastMessage.getString(lastMessage.getColumnIndex("address"))));
                                 
                                 try {
                                     getContentResolver().insert(Messages_Data.CONTENT_URI, inbox);
@@ -237,7 +237,7 @@ public class Communication extends Aware_Sensor {
                                 sent.put(Messages_Data.TIMESTAMP, lastMessage.getLong(lastMessage.getColumnIndex("date")));
                                 sent.put(Messages_Data.DEVICE_ID, Aware.getSetting(getApplicationContext(), Aware_Preferences.DEVICE_ID));
                                 sent.put(Messages_Data.TYPE, MESSAGE_SENT);
-                                sent.put(Messages_Data.TRACE, Encrypter.hashSHA1(lastMessage.getString(lastMessage.getColumnIndex("address"))));
+                                sent.put(Messages_Data.TRACE, Encrypter.hashPhone(getApplicationContext(), lastMessage.getString(lastMessage.getColumnIndex("address"))));
                                 
                                 try {
                                     getContentResolver().insert(Messages_Data.CONTENT_URI, sent);

--- a/aware-core/src/main/java/com/aware/Telephony.java
+++ b/aware-core/src/main/java/com/aware/Telephony.java
@@ -270,9 +270,9 @@ public class Telephony extends Aware_Sensor {
             rowData.put(Telephony_Data.TIMESTAMP, timestamp);
             rowData.put(Telephony_Data.DEVICE_ID, device_id);
             rowData.put(Telephony_Data.DATA_ENABLED, telephonyManager.getDataState());
-            rowData.put(Telephony_Data.IMEI_MEID_ESN, Encrypter.hashSHA1(telephonyManager.getDeviceId()));
+            rowData.put(Telephony_Data.IMEI_MEID_ESN, Encrypter.hash(mContext, telephonyManager.getDeviceId()));
             rowData.put(Telephony_Data.SOFTWARE_VERSION, telephonyManager.getDeviceSoftwareVersion());
-            rowData.put(Telephony_Data.LINE_NUMBER, Encrypter.hashSHA1(telephonyManager.getLine1Number()));
+            rowData.put(Telephony_Data.LINE_NUMBER, Encrypter.hashPhone(mContext, telephonyManager.getLine1Number()));
             rowData.put(Telephony_Data.NETWORK_COUNTRY_ISO_MCC, telephonyManager.getNetworkCountryIso());
             rowData.put(Telephony_Data.NETWORK_OPERATOR_CODE, telephonyManager.getNetworkOperator());
             rowData.put(Telephony_Data.NETWORK_OPERATOR_NAME, telephonyManager.getNetworkOperatorName());
@@ -281,8 +281,8 @@ public class Telephony extends Aware_Sensor {
             rowData.put(Telephony_Data.SIM_STATE, telephonyManager.getSimState());
             rowData.put(Telephony_Data.SIM_OPERATOR_CODE, telephonyManager.getSimOperator());
             rowData.put(Telephony_Data.SIM_OPERATOR_NAME, telephonyManager.getSimOperatorName());
-            rowData.put(Telephony_Data.SIM_SERIAL, Encrypter.hashSHA1(telephonyManager.getSimSerialNumber()));
-            rowData.put(Telephony_Data.SUBSCRIBER_ID, Encrypter.hashSHA1(telephonyManager.getSubscriberId()));
+            rowData.put(Telephony_Data.SIM_SERIAL, Encrypter.hash(mContext, telephonyManager.getSimSerialNumber()));
+            rowData.put(Telephony_Data.SUBSCRIBER_ID, Encrypter.hash(mContext, telephonyManager.getSubscriberId()));
 
             try {
                 mContext.getContentResolver().insert(Telephony_Data.CONTENT_URI, rowData);


### PR DESCRIPTION
PR for denzilferreira/aware-client#40 (hashing).  Not ready to be merged yet.

- Any first thoughts?  More comments in the issue.
- Any disadvantage to combining all the hash algorithms into `hashGeneric` ?
- I have gone ahead and replaced all calls to hash to this on.
- Is getSetting(context) supposed to be a fast operation?
- It would be safe to let us internally test some before merging, but I would be interested on your current thoughts for likelihood.

Commit message below:


- Encrypter.hash(): Hash things, taking into account the
  "hash_function" and "hash_salt" settings.
- Encrypter.hashPhone(): Hash phone numbers.  Can take extra
  procedures for normalization or salting if desired.

New settings:

- "hash_function": ""=SHA-1 (default), "MD5", "SHA-1", "SHA-256",
  "SHA-512" (must be these exact java stardard names).  If an invalid
  name, default to "SHA-1".
- "hash_salt": If given, hash (text+SALT) instead of (text).  Defaults
  to "".  If "device_id", then hash using Aware's device_id to prevent
  linking between people.
- "hash_function_phone": A different hash function for phones.  This
  is slightly misnamed, because the stardard hash_function is used.
  This allows one to normalize the number (remove all digits except
  0-9 and "+") (value="normalize"), or salt with device_id
  (value="device_id"), or hash only the last six digits
  (value="last6").
- These settings are currently not visible in the UI since normal
  users should not need to use them.