### PR TITLE
Add geofencing support to Locations probe.

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware_Preferences.java
+++ b/aware-core/src/main/java/com/aware/Aware_Preferences.java
@@ -194,6 +194,15 @@ public class Aware_Preferences {
     public static final String LOCATION_EXPIRATION_TIME = "location_expiration_time";
 
     /**
+     * Location geofence.  If given and location does NOT fall within, then do not
+     * record location points.
+     * Format: "fence1 fence2 ..." (space separated string)
+     *   Circle fence: "lat,lon,radius".  Radius in METERS.
+     *   Rectangle fence: "rect,lat1,lon1,lat2,lon2". Literal "rect", then lats/lons.
+     */
+    public static final String LOCATION_GEOFENCE = "location_geofence";
+
+    /**
      * Activate/deactivate light sensor log (boolean)
      */
     public static final String STATUS_LIGHT = "status_light";


### PR DESCRIPTION
This adds support for geofencing of locations.  Locations are only recorded if within one of the fences, other wise blank values with label=`outofbounds` is recorded.

Here is a sample fence, a circle of radius 700m and a rectangle: `60.185222,24.821330,700 rect,60.171101,24.914507,60.160396,24.821774`

- Should the location sensor record "null" instead of zeros when there is no data?
- Telephony sensor appears to be able to record location, I haven't handled that yet.

I have been testing this, but will continue to do so more.  Appears to work so far.


Commit message:

- location_geofence setting:
     Location geofence.  If given and location does NOT fall within,
     then do not record location points.
     Format: "fence1 fence2 ..." (space separated string)
       Circle fence: "lat,lon,radius".  Radius in METERS.
       Rectangle fence: "rect,lat1,lon1,lat2,lon2". Literal "rect",
         then lats/lons.
- Denied locations have a label of "outofbounds", DB row still is
  inserted but with no location data.
- Telephony sensor also has location data, this should use fencing
  also.