### PR TITLE
Accessibility services: clarify instructions for activating

### DIFF
--- a/aware-core/src/main/java/com/aware/Applications.java
+++ b/aware-core/src/main/java/com/aware/Applications.java
@@ -444,7 +444,7 @@ public class Applications extends AccessibilityService {
         if (!isAccessibilityEnabled(c)) {
             NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(c);
             mBuilder.setSmallIcon(R.drawable.ic_stat_aware_accessibility);
-            mBuilder.setContentTitle("AWARE configuration");
+            mBuilder.setContentTitle("Please enable AWARE");
             mBuilder.setContentText(c.getResources().getString(R.string.aware_activate_accessibility));
             mBuilder.setAutoCancel(true);
             mBuilder.setOnlyAlertOnce(true); //notify the user only once

--- a/aware-core/src/main/res/values/strings.xml
+++ b/aware-core/src/main/res/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="aware_auto_update_version">"???"</string>
     <string name="aware_device_id">AWARE Device ID</string>
     <string name="aware_esm_questions">Mobile ESM waiting...</string>
-    <string name="aware_activate_accessibility">Activate AWARE in Accessibility Services.</string>
+    <string name="aware_activate_accessibility">Click here and activate AWARE in Accessibility Services.</string>
     <string name="aware_team">Team</string>
     <string name="aware_qrcode">QRCode</string>
     <string name="aware_sync">Sync</string>


### PR DESCRIPTION
This is a simple pull request.  I have observed several people not realizing you can click the notification to go to accessibility settings, so I labeled it as such.

However, does this work on all android versions?