### PR TITLE
Add some options for webservice uploading

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware_Preferences.java
+++ b/aware-core/src/main/java/com/aware/Aware_Preferences.java
@@ -465,6 +465,20 @@ public class Aware_Preferences {
     public static final String FREQUENCY_WEBSERVICE = "frequency_webservice";
 
     /**
+     * AWARE webservice simple: don't sync tables.  See webservice_remove_data for how
+     * this interacts with /latest.
+     */
+    public static final String WEBSERVICE_SIMPLE = "webservice_simple";
+
+    /**
+     * AWARE webservice remove data: Always delete data after it is uploaded.  User beware,
+     * this may break some plugins!  If this AND webservice_simple are true, then do not do
+     * the /latest calls, and the client only contacts servers if there is new data (as
+     * detected by more than zero rows in the database).
+     */
+    public static final String WEBSERVICE_REMOVE_DATA = "webservice_remove_data";
+
+    /**
      * How frequently to clean old data?
      * 0 - never
      * 1 - weekly

--- a/aware-core/src/main/res/xml/aware_preferences.xml
+++ b/aware-core/src/main/res/xml/aware_preferences.xml
@@ -3,36 +3,6 @@
     android:key="aware_preferences"
     android:title="@string/app_name">
     <PreferenceCategory
-        android:key="debug_flags"
-        android:title="Developer" >
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="debug_flag"
-            android:persistent="true"
-            android:summary="@string/aware_debug_summary"
-            android:title="@string/aware_debug_title" />
-        <EditTextPreference
-            android:defaultValue="AWARE"
-            android:dependency="debug_flag"
-            android:key="debug_tag"
-            android:persistent="true"
-            android:summary="@string/aware_debug_tag_summary"
-            android:title="@string/aware_debug_tag" />
-        <EditTextPreference
-            android:defaultValue=""
-            android:selectable="false"
-            android:key="aware_version"
-            android:persistent="true"
-            android:summary="@string/aware_auto_update_version"
-            android:title="@string/aware_version" />
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="debug_db_slow"
-            android:persistent="true"
-            android:summary="No database storage with high-performance sensors (e.g., accelerometer, gyroscope, etc.)"
-            android:title="Lightweight I/O" />
-    </PreferenceCategory>
-    <PreferenceCategory
         android:key="device_ids"
         android:title="Device" >
         <EditTextPreference
@@ -47,6 +17,13 @@
             android:summary=""
             android:defaultValue=""
             android:title="@string/aware_device_label" />
+        <EditTextPreference
+            android:defaultValue=""
+            android:selectable="false"
+            android:key="aware_version"
+            android:persistent="true"
+            android:summary="@string/aware_auto_update_version"
+            android:title="@string/aware_version" />
     </PreferenceCategory>
     <PreferenceCategory
         android:key="sensors"
@@ -769,6 +746,54 @@
                 android:summary="Never"
                 android:title="Clean-up old data?" />
         </PreferenceScreen>
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="advanced"
+        android:summary="Advanced"
+        android:title="Advanced">
+        <PreferenceScreen
+            android:key="advanced"
+            android:summary="For advanced users and developers"
+            android:title="Advanced options">
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="debug_flag"
+                android:persistent="true"
+                android:summary="@string/aware_debug_summary"
+                android:title="@string/aware_debug_title" />
+
+            <EditTextPreference
+                android:defaultValue="AWARE"
+                android:dependency="debug_flag"
+                android:key="debug_tag"
+                android:persistent="true"
+                android:summary="@string/aware_debug_tag_summary"
+                android:title="@string/aware_debug_tag" />
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="debug_db_slow"
+                android:persistent="true"
+                android:summary="No database storage with high-performance sensors (e.g., accelerometer, gyroscope, etc.)"
+                android:title="Lightweight I/O" />
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="webservice_simple"
+                android:persistent="true"
+                android:summary="Don't sync table metadata"
+                android:title="Simple webservice" />
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="webservice_remove_data"
+                android:persistent="true"
+                android:summary="This may cause problems with some sensors or plugins."
+                android:title="Remove all data once uploaded" />
+        </PreferenceScreen>
+
     </PreferenceCategory>
 
 </PreferenceScreen>

--- a/aware-phone/src/main/java/com/aware/phone/Aware_Client.java
+++ b/aware-phone/src/main/java/com/aware/phone/Aware_Client.java
@@ -2101,5 +2101,29 @@ public class Aware_Client extends Aware_Activity {
             }
         });
         if (Aware.isStudy(awareContext)) device_label.setSelectable(false);
+
+
+        final CheckBoxPreference webservice_simple = (CheckBoxPreference) findPreference(Aware_Preferences.WEBSERVICE_SIMPLE);
+        webservice_simple.setChecked(Aware.getSetting(awareContext, Aware_Preferences.WEBSERVICE_SIMPLE).equals("true"));
+        webservice_simple.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                Aware.setSetting(awareContext, Aware_Preferences.WEBSERVICE_SIMPLE, webservice_simple.isChecked());
+                return true;
+            }
+        });
+        if (Aware.isStudy(awareContext)) webservice_simple.setSelectable(false);
+
+        final CheckBoxPreference webservice_remove_data = (CheckBoxPreference) findPreference(Aware_Preferences.WEBSERVICE_REMOVE_DATA);
+        webservice_remove_data.setChecked(Aware.getSetting(awareContext, Aware_Preferences.WEBSERVICE_REMOVE_DATA).equals("true"));
+        webservice_remove_data.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                Aware.setSetting(awareContext, Aware_Preferences.WEBSERVICE_REMOVE_DATA, webservice_remove_data.isChecked());
+                return true;
+            }
+        });
+        if (Aware.isStudy(awareContext)) webservice_remove_data.setSelectable(false);
+
     }
 }

--- a/aware-phone/src/main/res/xml/aware_preferences.xml
+++ b/aware-phone/src/main/res/xml/aware_preferences.xml
@@ -3,36 +3,6 @@
     android:key="aware_preferences"
     android:title="@string/app_name">
     <PreferenceCategory
-        android:key="debug_flags"
-        android:title="Developer">
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="debug_flag"
-            android:persistent="true"
-            android:summary="@string/aware_debug_summary"
-            android:title="@string/aware_debug_title" />
-        <EditTextPreference
-            android:defaultValue="AWARE"
-            android:dependency="debug_flag"
-            android:key="debug_tag"
-            android:persistent="true"
-            android:summary="@string/aware_debug_tag_summary"
-            android:title="@string/aware_debug_tag" />
-        <EditTextPreference
-            android:defaultValue=""
-            android:selectable="false"
-            android:key="aware_version"
-            android:persistent="true"
-            android:summary="@string/aware_auto_update_version"
-            android:title="@string/aware_version" />
-        <CheckBoxPreference
-            android:defaultValue="false"
-            android:key="debug_db_slow"
-            android:persistent="true"
-            android:summary="No database storage with high-performance sensors (e.g., accelerometer, gyroscope, etc.)"
-            android:title="Lightweight I/O" />
-    </PreferenceCategory>
-    <PreferenceCategory
         android:key="device_ids"
         android:title="Device">
         <EditTextPreference
@@ -47,6 +17,13 @@
             android:persistent="true"
             android:summary=""
             android:title="@string/aware_device_label" />
+        <EditTextPreference
+            android:defaultValue=""
+            android:selectable="false"
+            android:key="aware_version"
+            android:persistent="true"
+            android:summary="@string/aware_auto_update_version"
+            android:title="@string/aware_version" />
     </PreferenceCategory>
     <PreferenceCategory
         android:key="sensors"
@@ -867,6 +844,54 @@
                 android:summary="Never"
                 android:title="Clean-up old data?" />
         </PreferenceScreen>
+    </PreferenceCategory>
+
+    <PreferenceCategory
+        android:key="advanced"
+        android:summary="Advanced"
+        android:title="Advanced">
+        <PreferenceScreen
+            android:key="advanced"
+            android:summary="For advanced users and developers"
+            android:title="Advanced options">
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="debug_flag"
+                android:persistent="true"
+                android:summary="@string/aware_debug_summary"
+                android:title="@string/aware_debug_title" />
+
+            <EditTextPreference
+                android:defaultValue="AWARE"
+                android:dependency="debug_flag"
+                android:key="debug_tag"
+                android:persistent="true"
+                android:summary="@string/aware_debug_tag_summary"
+                android:title="@string/aware_debug_tag" />
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="debug_db_slow"
+                android:persistent="true"
+                android:summary="No database storage with high-performance sensors (e.g., accelerometer, gyroscope, etc.)"
+                android:title="Lightweight I/O" />
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="webservice_simple"
+                android:persistent="true"
+                android:summary="Don't sync table metadata"
+                android:title="Simple webservice" />
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="webservice_remove_data"
+                android:persistent="true"
+                android:summary="This may cause problems with some sensors or plugins."
+                android:title="Remove all data once uploaded" />
+        </PreferenceScreen>
+
     </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
Hi,

I'm not sure if you will want this, but these patches add two variables `webservice_stateless` and `webservice_only`, which if combined will give this the behavior of the iOS app and remove all data once it is uploaded.  This is to user-visible anywhere, so is only activated if you like with a server that supports it.  The people running the study have to be clever enough to know that it does not work with all probes or plugins, and know the implications of not doing a three-phase sync.  I would consider it advanced use.

Note that indentation is wrong in this patch (to minimize the diff).  If you want to accept it, I will fix up the indentation first and then you can take it.

Thanks,

- Richard



Commit message:

- webservice_stateless: don't /create_table: in this case, the server
  saves all raw data and figures out what to do.
- webservice_only: removes data once it is uploaded.  May be
  incompatible with some sensors, but it seems to work so far.
- webservice_only and webservice_stateless: if both are given, then do
  not do /latest, and instead upload all data in the database.
- This patch introduces improper indentation, but it minimizes the
  divergence from upstream and is localized.