### PR TITLE
Join study: Change to use toast instead of notification

### DIFF
--- a/aware-core/src/main/java/com/aware/utils/StudyUtils.java
+++ b/aware-core/src/main/java/com/aware/utils/StudyUtils.java
@@ -80,14 +80,7 @@ public class StudyUtils extends IntentService {
                 return;
             }
 
-            NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(getApplicationContext());
-            mBuilder.setSmallIcon(R.drawable.ic_action_aware_studies);
-            mBuilder.setContentTitle("AWARE");
-            mBuilder.setContentText("Thanks for joining the study!");
-            mBuilder.setAutoCancel(true);
-
-            NotificationManager notManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-            notManager.notify(33, mBuilder.build());
+            Toast.makeText(getApplicationContext(), "Thanks for joining the study!", Toast.LENGTH_LONG).show();
 
             if (Aware.DEBUG) Log.d(Aware.TAG, "Study configs: " + configs_study.toString(5));
 


### PR DESCRIPTION
- When a study is joined, don't use a notification that needs to be
  dismissed, but a toast instead.  Toast content is the same as the
  notification content.