### PR TITLE
Reduce diff in aware_preferences.xml between aware-core and aware-phone 

### DIFF
--- a/aware-core/src/main/res/xml/aware_preferences.xml
+++ b/aware-core/src/main/res/xml/aware_preferences.xml
@@ -4,7 +4,7 @@
     android:title="@string/app_name">
     <PreferenceCategory
         android:key="device_ids"
-        android:title="Device" >
+        android:title="Device">
         <EditTextPreference
             android:key="device_id"
             android:persistent="true"
@@ -28,7 +28,7 @@
     <PreferenceCategory
         android:key="sensors"
         android:summary="AWARE default sensors"
-        android:title="Sensors" >
+        android:title="Sensors">
 
         <PreferenceScreen
             android:key="accelerometer"
@@ -211,10 +211,11 @@
 
             <PreferenceScreen
                 android:key="esm_creator"
-                android:title="ESM Creator - beta"
-                android:summary="Create and schedule questionnaires">
-                <intent android:targetPackage="com.niels.esmgenerator"
-                    android:targetClass="com.niels.esmgenerator.MainActivity"/>
+                android:summary="Create and schedule questionnaires"
+                android:title="ESM Creator - beta">
+                <intent
+                    android:targetClass="com.niels.esmgenerator.MainActivity"
+                    android:targetPackage="com.niels.esmgenerator" />
             </PreferenceScreen>
 
         </PreferenceScreen>
@@ -302,9 +303,9 @@
             <EditTextPreference
                 android:defaultValue="150"
                 android:dependency="status_location_gps"
+                android:inputType="number"
                 android:key="min_location_gps_accuracy"
                 android:persistent="true"
-                android:inputType="number"
                 android:summary="Desired GPS accuracy in meters (default = 150). 0 keeps GPS always on."
                 android:title="GPS accuracy" />
 
@@ -334,9 +335,9 @@
             <EditTextPreference
                 android:defaultValue="300"
                 android:dependency="status_location_gps"
+                android:inputType="number"
                 android:key="location_expiration_time"
                 android:persistent="true"
-                android:inputType="number"
                 android:summary="300 seconds"
                 android:title="Location expires after..." />
         </PreferenceScreen>
@@ -639,7 +640,7 @@
     <PreferenceCategory
         android:key="data_exchange"
         android:summary="Webservices, MQTT"
-        android:title="Context exchange protocols" >
+        android:title="Context exchange protocols">
         <PreferenceScreen
             android:key="mqtt"
             android:summary="Allows remove questionnaires, P2P context exchange"
@@ -650,7 +651,7 @@
                 android:defaultValue="false"
                 android:key="status_mqtt"
                 android:persistent="true"
-                android:title="Active" />
+                android:title="Connect" />
 
             <EditTextPreference
                 android:key="mqtt_server"
@@ -722,6 +723,13 @@
                 android:summary="Sync only on Wi-Fi"
                 android:title="Wi-Fi only" />
 
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="webservice_charging"
+                android:persistent="true"
+                android:summary="Sync only while charging"
+                android:title="Charging only" />
+
             <EditTextPreference
                 android:defaultValue="30"
                 android:inputType="number"
@@ -729,13 +737,6 @@
                 android:persistent="true"
                 android:summary="30 minutes"
                 android:title="Sync interval (in minutes, 0 to disable)." />
-
-            <CheckBoxPreference
-                android:defaultValue="false"
-                android:key="webservice_charging"
-                android:persistent="true"
-                android:summary="Only sync while charging"
-                android:title="Charging only" />
 
             <ListPreference
                 android:defaultValue="0"

--- a/aware-phone/src/main/res/xml/aware_preferences.xml
+++ b/aware-phone/src/main/res/xml/aware_preferences.xml
@@ -12,10 +12,10 @@
             android:summary="UUID:"
             android:title="@string/aware_device_id" />
         <EditTextPreference
-            android:defaultValue=""
             android:key="device_label"
             android:persistent="true"
             android:summary=""
+            android:defaultValue=""
             android:title="@string/aware_device_label" />
         <EditTextPreference
             android:defaultValue=""
@@ -47,8 +47,8 @@
                 android:title="Activate" />
 
             <ListPreference
-                android:defaultValue="200000"
                 android:dependency="status_accelerometer"
+                android:defaultValue="200000"
                 android:entries="@array/frequency_readable"
                 android:entryValues="@array/frequency_values"
                 android:key="frequency_accelerometer"
@@ -97,8 +97,8 @@
                 android:title="Application installations" />
             <CheckBoxPreference
                 android:defaultValue="false"
-                android:dependency="status_applications"
                 android:key="status_keyboard"
+                android:dependency="status_applications"
                 android:persistent="true"
                 android:summary="Logs keyboard input (no passwords)"
                 android:title="Keyboard" />
@@ -134,8 +134,8 @@
                 android:title="Activate" />
 
             <ListPreference
-                android:defaultValue="200000"
                 android:dependency="status_barometer"
+                android:defaultValue="200000"
                 android:entries="@array/frequency_readable"
                 android:entryValues="@array/frequency_values"
                 android:key="frequency_barometer"
@@ -264,8 +264,8 @@
                 android:title="Active" />
 
             <ListPreference
-                android:defaultValue="200000"
                 android:dependency="status_gravity"
+                android:defaultValue="200000"
                 android:entries="@array/frequency_readable"
                 android:entryValues="@array/frequency_values"
                 android:key="frequency_gravity"
@@ -298,8 +298,8 @@
                 android:title="Active" />
 
             <ListPreference
-                android:defaultValue="200000"
                 android:dependency="status_gyroscope"
+                android:defaultValue="200000"
                 android:entries="@array/frequency_readable"
                 android:entryValues="@array/frequency_values"
                 android:key="frequency_gyroscope"
@@ -335,9 +335,9 @@
             <EditTextPreference
                 android:defaultValue="180"
                 android:dependency="status_location_gps"
-                android:inputType="number"
                 android:key="frequency_location_gps"
                 android:persistent="true"
+                android:inputType="number"
                 android:summary="X in seconds (default = 180). 0 is always on."
                 android:title="GPS update frequency" />
             <EditTextPreference
@@ -359,17 +359,17 @@
             <EditTextPreference
                 android:defaultValue="300"
                 android:dependency="status_location_network"
-                android:inputType="number"
                 android:key="frequency_location_network"
                 android:persistent="true"
+                android:inputType="number"
                 android:summary="X in seconds (default = 300). 0 will keep network triangulation always on."
                 android:title="Network update frequency" />
             <EditTextPreference
                 android:defaultValue="1500"
                 android:dependency="status_location_network"
-                android:inputType="number"
                 android:key="min_location_network_accuracy"
                 android:persistent="true"
+                android:inputType="number"
                 android:summary="Desired network accuracy in meters (default = 1500). 0 keeps network triangulation always on."
                 android:title="Network accuracy" />
             <EditTextPreference
@@ -398,8 +398,8 @@
                 android:title="Active" />
 
             <ListPreference
-                android:defaultValue="200000"
                 android:dependency="status_light"
+                android:defaultValue="200000"
                 android:entries="@array/frequency_readable"
                 android:entryValues="@array/frequency_values"
                 android:key="frequency_light"
@@ -432,8 +432,8 @@
                 android:title="Active" />
 
             <ListPreference
-                android:defaultValue="200000"
                 android:dependency="status_linear_accelerometer"
+                android:defaultValue="200000"
                 android:entries="@array/frequency_readable"
                 android:entryValues="@array/frequency_values"
                 android:key="frequency_linear_accelerometer"
@@ -497,8 +497,8 @@
                 android:title="Active" />
 
             <ListPreference
-                android:defaultValue="200000"
                 android:dependency="status_magnetometer"
+                android:defaultValue="200000"
                 android:entries="@array/frequency_readable"
                 android:entryValues="@array/frequency_values"
                 android:key="frequency_magnetometer"
@@ -581,8 +581,8 @@
                 android:title="Active" />
 
             <ListPreference
-                android:defaultValue="200000"
                 android:dependency="status_proximity"
+                android:defaultValue="200000"
                 android:entries="@array/frequency_readable"
                 android:entryValues="@array/frequency_values"
                 android:key="frequency_proximity"
@@ -615,8 +615,8 @@
                 android:title="Active" />
 
             <ListPreference
-                android:defaultValue="200000"
                 android:dependency="status_rotation"
+                android:defaultValue="200000"
                 android:entries="@array/frequency_readable"
                 android:entryValues="@array/frequency_values"
                 android:key="frequency_rotation"
@@ -667,8 +667,8 @@
                 android:title="Active" />
 
             <ListPreference
-                android:defaultValue="200000"
                 android:dependency="status_temperature"
+                android:defaultValue="200000"
                 android:entries="@array/frequency_readable"
                 android:entryValues="@array/frequency_values"
                 android:key="frequency_temperature"
@@ -807,11 +807,11 @@
                 android:title="Active" />
 
             <EditTextPreference
-                android:defaultValue="https://api.awareframework.com/index.php"
                 android:key="webservice_server"
                 android:persistent="true"
                 android:summary="URL"
-                android:title="Study URL" />
+                android:title="Study URL"
+                android:defaultValue="https://api.awareframework.com/index.php"/>
 
             <CheckBoxPreference
                 android:defaultValue="false"


### PR DESCRIPTION
- There should be no differences in meaning before and after this
  change.
- A diff of the two files now shows only the main difference: the
  toolbars and icons.
- Future changes can be more easily synced between the files using
  diff/patch or a graphical merge tool.