### PR TITLE
Add webservice_silent option: don't show notification when uploading

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -778,6 +778,9 @@ public class Aware extends Service {
         global_settings.add(Aware_Preferences.FREQUENCY_WEBSERVICE);
         global_settings.add(Aware_Preferences.WEBSERVICE_WIFI_ONLY);
         global_settings.add(Aware_Preferences.WEBSERVICE_SERVER);
+        global_settings.add(Aware_Preferences.WEBSERVICE_SIMPLE);
+        global_settings.add(Aware_Preferences.WEBSERVICE_REMOVE_DATA);
+        global_settings.add(Aware_Preferences.WEBSERVICE_SILENT);
         global_settings.add(Aware_Preferences.STATUS_APPLICATIONS);
         global_settings.add(Applications.STATUS_AWARE_ACCESSIBILITY);
 

--- a/aware-core/src/main/java/com/aware/Aware_Preferences.java
+++ b/aware-core/src/main/java/com/aware/Aware_Preferences.java
@@ -487,6 +487,13 @@ public class Aware_Preferences {
      */
     public static final String WEBSERVICE_REMOVE_DATA = "webservice_remove_data";
 
+
+    /**
+     * AWARE webservice silence: If "true", then don't show a notification when uploading
+     * data.  This only affects tasks that interact with webservice in the background.
+     */
+    public static final String WEBSERVICE_SILENT = "webservice_silent";
+
     /**
      * How frequently to clean old data?
      * 0 - never

--- a/aware-core/src/main/java/com/aware/utils/WebserviceHelper.java
+++ b/aware-core/src/main/java/com/aware/utils/WebserviceHelper.java
@@ -60,9 +60,10 @@ public class WebserviceHelper extends IntentService {
         if (Aware.DEBUG)
             Log.d(Aware.TAG, "Synching all the databases...");
 
-        notManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-        notifyUser("Synching initiated...", false, true);
-
+        if (!Aware.getSetting(getApplicationContext(), Aware_Preferences.WEBSERVICE_SILENT).equals("true")) {
+            notManager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+            notifyUser("Synching initiated...", false, true);
+        }
         sync_start = System.currentTimeMillis();
     }
 
@@ -261,7 +262,9 @@ public class WebserviceHelper extends IntentService {
                     if (DEBUG)
                         Log.d(Aware.TAG, "Syncing " + TOTAL_RECORDS + " records from " + DATABASE_TABLE);
 
-                    notifyUser("Syncing " + TOTAL_RECORDS + " from " + DATABASE_TABLE, false, true);
+                    if (!Aware.getSetting(getApplicationContext(), Aware_Preferences.WEBSERVICE_SILENT).equals("true")) {
+                        notifyUser("Syncing " + TOTAL_RECORDS + " from " + DATABASE_TABLE, false, true);
+                    }
 
                     long start = System.currentTimeMillis();
 
@@ -365,7 +368,9 @@ public class WebserviceHelper extends IntentService {
                                     if (DEBUG)
                                         Log.d(Aware.TAG, "Deleted local old records for " + DATABASE_TABLE);
 
-                                    notifyUser("Cleaned old records from " + DATABASE_TABLE, false, true);
+                                    if (!Aware.getSetting(getApplicationContext(), Aware_Preferences.WEBSERVICE_SILENT).equals("true")) {
+                                        notifyUser("Cleaned old records from " + DATABASE_TABLE, false, true);
+                                    }
                                 }
                             }
                         }
@@ -410,6 +415,8 @@ public class WebserviceHelper extends IntentService {
         if (Aware.DEBUG)
             Log.d(Aware.TAG, "Finished synching all the databases in " + DateUtils.formatElapsedTime((System.currentTimeMillis() - sync_start) / 1000));
 
-        notifyUser("Finished syncing", true, false);
+        if (!Aware.getSetting(getApplicationContext(), Aware_Preferences.WEBSERVICE_SILENT).equals("true")) {
+            notifyUser("Finished syncing", true, false);
+        }
     }
 }

--- a/aware-core/src/main/res/xml/aware_preferences.xml
+++ b/aware-core/src/main/res/xml/aware_preferences.xml
@@ -793,6 +793,13 @@
                 android:persistent="true"
                 android:summary="This may cause problems with some sensors or plugins."
                 android:title="Remove all data once uploaded" />
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="webservice_silent"
+                android:persistent="true"
+                android:summary="Don't show a notification every time data uploaded"
+                android:title="Quiet webservice" />
         </PreferenceScreen>
 
     </PreferenceCategory>

--- a/aware-phone/src/main/java/com/aware/phone/Aware_Client.java
+++ b/aware-phone/src/main/java/com/aware/phone/Aware_Client.java
@@ -2125,5 +2125,17 @@ public class Aware_Client extends Aware_Activity {
         });
         if (Aware.isStudy(awareContext)) webservice_remove_data.setSelectable(false);
 
+        final CheckBoxPreference webservice_silent = (CheckBoxPreference) findPreference(Aware_Preferences.WEBSERVICE_SILENT);
+        webservice_silent.setChecked(Aware.getSetting(awareContext, Aware_Preferences.WEBSERVICE_SILENT).equals("true"));
+        webservice_silent.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                Aware.setSetting(awareContext, Aware_Preferences.WEBSERVICE_SILENT, webservice_silent.isChecked());
+                return true;
+            }
+        });
+        // Users can always adjust this!  But it might be overwritten on next config update.
+        //if (Aware.isStudy(awareContext)) webservice_silent.setSelectable(false);
+
     }
 }

--- a/aware-phone/src/main/java/com/aware/phone/ui/Aware_Activity.java
+++ b/aware-phone/src/main/java/com/aware/phone/ui/Aware_Activity.java
@@ -149,6 +149,7 @@ public class Aware_Activity extends AppCompatPreferenceActivity {
             startActivity(about_us);
         }
         if (item.getTitle().toString().equalsIgnoreCase(getResources().getString(R.string.aware_sync))) {
+            Toast.makeText(getApplicationContext(), "AWARE: Syncing data...", Toast.LENGTH_SHORT).show();
             Intent sync = new Intent(Aware.ACTION_AWARE_SYNC_DATA);
             sendBroadcast(sync);
         }

--- a/aware-phone/src/main/res/xml/aware_preferences.xml
+++ b/aware-phone/src/main/res/xml/aware_preferences.xml
@@ -890,6 +890,13 @@
                 android:persistent="true"
                 android:summary="This may cause problems with some sensors or plugins."
                 android:title="Remove all data once uploaded" />
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="webservice_silent"
+                android:persistent="true"
+                android:summary="Don't show a notification every time data uploaded"
+                android:title="Quiet webservice" />
         </PreferenceScreen>
 
     </PreferenceCategory>


### PR DESCRIPTION
Another low-hanging fruit: add an advanced option to not show notification when uploading data.  Also add toast which appears when you click manual upload button.  Also adds my three new webservice options to the `global_settings` hash in `Aware.java` - I think they should have been there before.

commit msg:

- This option surpresses the notification when uploading data.  For
  some studies, we shouldn't be so apparent.
- Option name webservice_silent, if "true" then do not show anything,
  all other values cause notification to be shown.
- A toast is added when clicking the manual upload button.  This
  provides some context to the manual upload button, so that if
  silent=true, the user still knows the click worked.
- This is visible in the UI and users can always adjust it, even if we
  are in a study (since it has no effects on data).  However, changes
  may be overwritten if config updated by server.