### PR TITLE
Option to donate usage data to AWARE project

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -1018,23 +1018,23 @@ public class Aware extends Service {
     public static class JoinStudy extends StudyUtils {
         @Override
         protected void onHandleIntent(Intent intent) {
-            String study_url = intent.getStringExtra(EXTRA_JOIN_STUDY);
+            String full_url = intent.getStringExtra(EXTRA_JOIN_STUDY);
 
-            if (Aware.DEBUG) Log.d(Aware.TAG, "Joining: " + study_url);
+            if (Aware.DEBUG) Log.d(Aware.TAG, "Joining: " + full_url);
+
+            Uri study_uri = Uri.parse(full_url);
+            // New study URL, chopping off query parameters.
+            String study_url = study_uri.getScheme()+"://"+study_uri.getHost()+"/"+study_uri.getPath();
+            String protocol = study_uri.getScheme();
 
             //Request study settings
             Hashtable<String, String> data = new Hashtable<>();
             data.put(Aware_Preferences.DEVICE_ID, Aware.getSetting(getApplicationContext(), Aware_Preferences.DEVICE_ID));
 
-            String protocol = study_url.substring(0, study_url.indexOf(":"));
-
             String answer;
             if (protocol.equals("https")) {
-
-                //Make sure we have the server's certificates for security
-                Intent ssl = new Intent(getApplicationContext(), SSLManager.class);
-                ssl.putExtra(SSLManager.EXTRA_SERVER, study_url);
-                startService(ssl);
+                // Get SSL certs
+                SSLManager.handleUrl(getApplicationContext(), full_url, true);
 
                 try {
                     answer = new Https(getApplicationContext(), SSLManager.getHTTPS(getApplicationContext(), study_url)).dataPOST(study_url, data, true);

--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -278,11 +278,6 @@ public class Aware extends Service {
             Aware.setSetting(getApplicationContext(), Aware_Preferences.WEBSERVICE_SERVER, "https://api.awareframework.com/index.php");
         }
 
-        //Load default awareframework.com SSL certificate for shared public plugins
-        Intent aware_SSL = new Intent(this, SSLManager.class);
-        aware_SSL.putExtra(SSLManager.EXTRA_SERVER, "https://api.awareframework.com/index.php");
-        startService(aware_SSL);
-
         DEBUG = Aware.getSetting(awareContext, Aware_Preferences.DEBUG_FLAG).equals("true");
         TAG = Aware.getSetting(awareContext, Aware_Preferences.DEBUG_TAG).length() > 0 ? Aware.getSetting(awareContext, Aware_Preferences.DEBUG_TAG) : TAG;
 
@@ -290,7 +285,10 @@ public class Aware extends Service {
 
         if (Aware.DEBUG) Log.d(TAG, "AWARE framework is created!");
 
-        new AsyncPing().execute();
+
+        if (Aware.getSetting(getApplicationContext(), Aware_Preferences.AWARE_DONATE_USAGE).equals("true")) {
+            new AsyncPing().execute();
+        }
 
         awareStatusMonitor = new Intent(this, Aware.class);
         repeatingIntent = PendingIntent.getService(getApplicationContext(), 0, awareStatusMonitor, 0);
@@ -300,6 +298,10 @@ public class Aware extends Service {
     private class AsyncPing extends AsyncTask<Void, Void, Boolean> {
         @Override
         protected Boolean doInBackground(Void... params) {
+            // Download the certificate, and block since we are already running in background
+            // and we need the certificate immediately.
+            SSLManager.downloadCertificate(awareContext, "api.awareframework.com", true);
+
             //Ping AWARE's server with awareContext device's information for framework's statistics log
             Hashtable<String, String> device_ping = new Hashtable<>();
             device_ping.put(Aware_Preferences.DEVICE_ID, Aware.getSetting(awareContext, Aware_Preferences.DEVICE_ID));

--- a/aware-core/src/main/java/com/aware/Aware_Preferences.java
+++ b/aware-core/src/main/java/com/aware/Aware_Preferences.java
@@ -495,6 +495,14 @@ public class Aware_Preferences {
     public static final String WEBSERVICE_SILENT = "webservice_silent";
 
     /**
+     * Key management strategy.
+     * - "once" = keys are not updated once downloaded.
+     * - "" = keys are updated as often as needed.
+     */
+    public static final String KEY_STRATEGY = "key_strategy";
+
+
+    /**
      * How frequently to clean old data?
      * 0 - never
      * 1 - weekly

--- a/aware-core/src/main/java/com/aware/Aware_Preferences.java
+++ b/aware-core/src/main/java/com/aware/Aware_Preferences.java
@@ -44,6 +44,12 @@ public class Aware_Preferences {
     public static final String AWARE_VERSION = "aware_version";
 
     /**
+     * Donate usage data to AWARE project.  Note that this only sends device ID and
+     * version information, no actual data of any sort.
+     */
+    public static final String AWARE_DONATE_USAGE = "aware_donate_usage";
+
+    /**
      * Activate/deactivate accelerometer log (boolean)
      */
     public static final String STATUS_ACCELEROMETER = "status_accelerometer";

--- a/aware-core/src/main/java/com/aware/utils/SSLManager.java
+++ b/aware-core/src/main/java/com/aware/utils/SSLManager.java
@@ -3,16 +3,28 @@ package com.aware.utils;
 import android.app.IntentService;
 import android.content.Context;
 import android.content.Intent;
+import android.icu.util.Output;
+import android.net.Uri;
 import android.util.Log;
 
 import com.aware.Aware;
+import com.aware.Aware_Preferences;
+import com.koushikdutta.async.future.Future;
 import com.koushikdutta.async.future.FutureCallback;
 import com.koushikdutta.ion.Ion;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Created by denzil on 15/12/15.
@@ -29,24 +41,88 @@ public class SSLManager extends IntentService {
 
     public SSLManager() { super(Aware.TAG + " SSL manager"); }
 
+    /**
+     * An intent handles a URL by getting a certificate.  It uses the new handling
+     * techniques, but currently it defaults to updating the certificate unconditionally.
+     * @param intent Intent with extra data aware_server = URL
+     */
     @Override
     protected void onHandleIntent(Intent intent) {
-        String server_url = intent.getStringExtra("aware_server");
+        String server_url = intent.getStringExtra(EXTRA_SERVER);
 
-        String aware_host = server_url.substring(0, server_url.indexOf("/index.php"));
-        aware_host = aware_host.substring(aware_host.indexOf("//")+2, aware_host.length());
+        handleUrl(getApplicationContext(), server_url, true);
+    }
 
-        File host_credentials = new File( getExternalFilesDir(null) + "/Documents/", "credentials/"+ aware_host );
+    //
+    // Entry point layer
+    //
+
+    /**
+     * Handle a study URL.  Fetch data from query parameters if it is there.  Otherwise,
+     * use the classic method of downloading the certificate over http.  Enforces the key
+     * management policy.
+     * @param context app context
+     * @param url full URL, including protocol and query arguments
+     * @param block if true, this method blocks, otherwise downloading is in background.
+     */
+    public static void handleUrl(Context context, String url, boolean block) {
+        Log.d(Aware.TAG, "Certificates: Handling URL: "+url);
+        // Warning: jelly_bean changes behavior of decoding "+".  Make sure that both
+        // " " and "+" are %-encoded.
+        Uri study_uri = Uri.parse(url);
+        String hostname = study_uri.getHost();
+        if (study_uri.getQuery() != null) {
+            // If it is in URL parameters, always unconditionally handle it
+            String crt = study_uri.getQueryParameter("crt");
+            String crt_url = study_uri.getQueryParameter("crt_url");
+            String crt_sha256 = study_uri.getQueryParameter("crt_sha256");
+            if (crt != null || crt_url != null || crt_sha256 != null)
+                if (Aware.DEBUG) Log.d(Aware.TAG, "Certificates: Handling URL via query parameters: " + hostname);
+            handleCrtParameters(context, hostname, crt, crt_sha256, crt_url);
+        } else {
+            if (Aware.getSetting(context, Aware_Preferences.KEY_STRATEGY).equals("once")) {
+                // With "once" management, we only retrieve if we have not gotten cert yet.
+                if (Aware.DEBUG) Log.d(Aware.TAG, "Certificates: Downloading crt if not present: " + hostname);
+                if (! hasCertificate(context, hostname)) {
+                    downloadCertificate(context, hostname, block);
+                } else {
+                    if (Aware.DEBUG) Log.d(Aware.TAG, "Certificates: Already present and key_management=once: " + hostname);
+                }
+            } else {
+                // Default management style: re-download certificate every time.
+                if (Aware.DEBUG) Log.d(Aware.TAG, "Certificates: Unconditionally downloading certificate: " + hostname);
+                downloadCertificate(context, hostname, block);
+            }
+        }
+    }
+
+
+    //
+    // Downloading/setting functions
+    //
+
+    /**
+     * Classic method: Download certificate unconditionally.  This is the old
+     * method of certificate fetching.  This method blocks if the block parameter is true,
+     * otherwise is nonblocking.
+     * @param context app contexto
+     * @param hostname Hostname to download.
+     * @param block If true, block until certificate retrieved, otherwise do not.
+     */
+    public static void downloadCertificate(Context context, String hostname, boolean block) {
+        File host_credentials = new File(context.getExternalFilesDir(null) + "/Documents/", "credentials/"+ hostname );
         host_credentials.mkdirs();
 
-        String exception_aware;
-        if( aware_host.equals("api.awareframework.com") ) {
-            exception_aware = "awareframework.com";
-        } else exception_aware = aware_host;
+        // api.awareframework.com is an exception: we download from a different host.
+        // cert_host is the host from which we actually download.
+        String cert_host;
+        if( hostname.equals("api.awareframework.com") ) {
+            cert_host = "awareframework.com";
+        } else cert_host = hostname;
 
-        Ion.with(getApplicationContext())
-                .load("http://" + exception_aware + "/public/server.crt")
-                .write(new File(getExternalFilesDir(null) + "/Documents/credentials/" + aware_host + "/server.crt"))
+        Future downloader = Ion.with(context.getApplicationContext())
+                .load("http://" + cert_host + "/public/server.crt")
+                .write(new File(context.getExternalFilesDir(null) + "/Documents/credentials/" + hostname + "/server.crt"))
                 .setCallback(new FutureCallback<File>() {
                     @Override
                     public void onCompleted(Exception e, File result) {
@@ -55,13 +131,120 @@ public class SSLManager extends IntentService {
                         }
                     }
                 });
+        if (block) {
+            try {
+                downloader.get();
+            } catch (java.lang.InterruptedException | ExecutionException e) {
+                // What to do here?
+            }
+        }
     }
+
+
+    /**
+     * Handle a certificate the new way, via the parameters crt, crt_sha256, and crt_url.
+     * If crt is given, use that data.  Otherwise, if crt_url is given, download crt from
+     * that URL.  In all cases, verify against crt_sha256.  Then save the certificate.
+     *
+     * @param context app context
+     * @param hostname hostname to save
+     * @param crt raw String certificate data (contents of file)
+     * @param crt_sha256 sha256 hash of certificate data to validate
+     * @param crt_url URL from which to fetch certificate if it is not given.
+     */
+    public static void handleCrtParameters(Context context, String hostname, String crt, String crt_sha256, String crt_url) {
+        if (Aware.DEBUG) {
+            Log.d(Aware.TAG, "handleCrtParameters");
+            Log.d(Aware.TAG, "crt=" + crt);
+            Log.d(Aware.TAG, "crt_url=" + crt_url);
+            Log.d(Aware.TAG, "crt_sha256=" + crt_sha256);
+        }
+
+        if (crt != null) {
+            crt = crt;
+            // use cert directly
+        } else if (crt_url != null) {
+            try {
+                InputStream crt_stream = new URL(crt_url).openStream();
+                // Convert input stream to String
+                BufferedReader br = new BufferedReader(new InputStreamReader(crt_stream));
+                StringBuilder sb = new StringBuilder();
+                // Someone please turn this into a proper way to get data from URL in java.
+                int nextchar;
+                while ((nextchar = br.read()) != -1) {
+                    sb.append((char)nextchar);
+                }
+                br.close();
+                // Final result that we actually need.
+                crt = sb.toString();
+            } catch (IOException e) {
+                Log.e(Aware.TAG, "Certificates: Can not download crt: " + crt_url);
+                // TODO: error handling
+                return;
+            }
+        } else {
+            // TODO: error handling
+            Log.e(Aware.TAG, "Certificates: Both crt and crt_url are null: ");
+            return ;
+        }
+
+        // Validate certificate using hash
+        if (crt_sha256 != null) {
+            String actual_hash = Encrypter.hashGeneric(crt, "SHA-256");
+            if ( ! actual_hash.equals(crt_sha256)) {
+                Log.e(Aware.TAG, "Invalid certificate hash: "+crt_sha256+"!="+actual_hash);
+                return;
+            }
+        }
+
+        // Set the certificate
+        setCertificate(context, hostname, crt);
+    }
+
+
+    //
+    // Utility functions
+    //
+
+    /**
+     * Do we have a certificate for this hostname?
+     * @param context context
+     * @param hostname hostname to check (only hostname, no protocol or anything.)
+     * @return true if a certificate exists, false otherwise
+     */
+    public static boolean hasCertificate(Context context, String hostname) {
+        File host_credentials = new File(context.getExternalFilesDir(null) + "/Documents/", "credentials/"+ hostname);
+        return host_credentials.exists();
+    }
+
+
+    /**
+     * Write a certificate do disk, given by name.
+     * @param context app context
+     * @param hostname hostname to check
+     * @param cert_data certificate data, as String.
+     */
+    public static void setCertificate(Context context, String hostname, String cert_data) {
+        File cert_file = new File(context.getExternalFilesDir(null) + "/Documents/credentials/" + hostname + "/server.crt");
+        try {
+            FileOutputStream stream = new FileOutputStream(cert_file);
+            OutputStreamWriter cert_f = new OutputStreamWriter(stream);
+            cert_f.write(cert_data);
+            cert_f.close();
+            Log.d(Aware.TAG, "Set certificate for " + hostname);
+        } catch (java.io.IOException e) {
+            Log.d(Aware.TAG, "Can not write certificate: " + cert_file);
+            e.printStackTrace();
+        }
+    }
+
+
 
     /**
      * Load the server.crt for HTTPS
-     * @param c
-     * @param server
-     * @return
+     * @param c context
+     * @param server server URL, http://{hostname}/index.php
+     * @return FileInputStream of certificate
      * @throws FileNotFoundException
      */
     public static InputStream getHTTPS(Context c, String server) throws FileNotFoundException {
@@ -80,9 +263,9 @@ public class SSLManager extends IntentService {
 
     /**
      * Load the server.crt for MQTT
-     * @param c
-     * @param server
-     * @return
+     * @param c context
+     * @param server server hostname
+     * @return Input stream of opened certificate.
      * @throws FileNotFoundException
      */
     public static InputStream getCA(Context c, String server) throws FileNotFoundException {

--- a/aware-core/src/main/res/xml/aware_preferences.xml
+++ b/aware-core/src/main/res/xml/aware_preferences.xml
@@ -24,6 +24,13 @@
             android:persistent="true"
             android:summary="@string/aware_auto_update_version"
             android:title="@string/aware_version" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="aware_donate_usage"
+            android:persistent="true"
+            android:title="Send AWARE team usage information"
+            android:summary="Send usage information (device id, application info), NOT actual data.  This supports AWARE funding."
+            />
     </PreferenceCategory>
     <PreferenceCategory
         android:key="sensors"

--- a/aware-phone/src/main/java/com/aware/phone/Aware_Client.java
+++ b/aware-phone/src/main/java/com/aware/phone/Aware_Client.java
@@ -2137,5 +2137,16 @@ public class Aware_Client extends Aware_Activity {
         // Users can always adjust this!  But it might be overwritten on next config update.
         //if (Aware.isStudy(awareContext)) webservice_silent.setSelectable(false);
 
+        final CheckBoxPreference aware_donate_usage = (CheckBoxPreference) findPreference(Aware_Preferences.AWARE_DONATE_USAGE);
+        aware_donate_usage.setChecked(Aware.getSetting(awareContext, Aware_Preferences.AWARE_DONATE_USAGE).equals("true"));
+        aware_donate_usage.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                Aware.setSetting(awareContext, Aware_Preferences.AWARE_DONATE_USAGE, aware_donate_usage.isChecked());
+                return true;
+            }
+        });
+        // Users can always choose to donate data, even if in a study.
+        //if (Aware.isStudy(awareContext)) aware_donate_data.setSelectable(false);
     }
 }

--- a/aware-phone/src/main/res/xml/aware_preferences.xml
+++ b/aware-phone/src/main/res/xml/aware_preferences.xml
@@ -24,6 +24,13 @@
             android:persistent="true"
             android:summary="@string/aware_auto_update_version"
             android:title="@string/aware_version" />
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:key="aware_donate_usage"
+            android:persistent="true"
+            android:title="Send AWARE team usage information"
+            android:summary="Send usage information (device id, application info), NOT actual data.  This supports AWARE funding."
+            />
     </PreferenceCategory>
     <PreferenceCategory
         android:key="sensors"


### PR DESCRIPTION
This is the start of a commit to make donating usage information optional.  By default it is off, but users can turn it on.  This commit isn't ready for pulling yet, but making the request to get feedback.

To-do:
- Currently, in Aware.java, it sends an intent to get the cert of the server's api.  I should do something about this still.  The comment implies that this is for the use getting plugins, but this now goes to the play store directly, so is it not necessary anymore?  However, presumably it is also necessary for sending the usage information.
- I was going to add the certificate-getting in the AsynchronousPing.  As part of this, I would add another function ensureCertificate or some such, which gets the certificate if it doesn't already exist.  It isn't very secure for certificates to be fetched at random times over non-ssl (but at the same time, there eventually needs to be a way to handle upgrading certs).
- I was going to add platform="android", packagename=..., and packageverision=... to the usage data that is sent.  I will also have it send these on the initial study registration, to provide a way to distinguish between android and iOS devices (though is there already a way to do this?) 

Any comments?

existing commit msg:

- Menu option which turns on the usage information.
- Usage information sent to api.awareframework.com, like before.
- Defaults to false, but can always be turned on by user, even if they
  are in a study.