### PR TITLE
Join toast: don't cancel if join_toast is null.

### DIFF
--- a/aware-core/src/main/java/com/aware/utils/StudyUtils.java
+++ b/aware-core/src/main/java/com/aware/utils/StudyUtils.java
@@ -178,6 +178,7 @@ public class StudyUtils extends IntentService {
 
     public void onDestroy() {
         // The toast may stay living forever if the service is destroyed before it starts.
-        JOIN_TOAST.cancel();
+        if (JOIN_TOAST != null)
+            JOIN_TOAST.cancel();
     }
 }


### PR DESCRIPTION
- I got a crash when this code was invoked when JOIN_TOAST was null.
  This provides safety.
- Perhaps it can get here if StudyUtils class invoked without the
  intent, or it fails before JOIN_TOAST is made?  (I'm not sure the root cause)