### PR TITLE
When joining studies/sending usage information, include package data.

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -13,6 +13,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.content.res.Configuration;
@@ -304,6 +305,17 @@ public class Aware extends Service {
             Hashtable<String, String> device_ping = new Hashtable<>();
             device_ping.put(Aware_Preferences.DEVICE_ID, Aware.getSetting(awareContext, Aware_Preferences.DEVICE_ID));
             device_ping.put("ping", String.valueOf(System.currentTimeMillis()));
+            device_ping.put("platform", "android");
+            try {
+                PackageInfo package_info = awareContext.getPackageManager().getPackageInfo(awareContext.getPackageName(), 0);
+                device_ping.put("package_name", package_info.packageName);
+                if (package_info.packageName.equals("com.aware.phone")) {
+                    device_ping.put("package_version_code", String.valueOf(package_info.versionCode));
+                    device_ping.put("package_version_name", String.valueOf(package_info.versionName));
+                }
+            } catch (PackageManager.NameNotFoundException e) {
+            }
+
             try {
                 new Https(awareContext, SSLManager.getHTTPS(getApplicationContext(), "https://api.awareframework.com/index.php")).dataPOST("https://api.awareframework.com/index.php/awaredev/alive", device_ping, true);
             } catch (FileNotFoundException e) {
@@ -1025,6 +1037,16 @@ public class Aware extends Service {
             //Request study settings
             Hashtable<String, String> data = new Hashtable<>();
             data.put(Aware_Preferences.DEVICE_ID, Aware.getSetting(getApplicationContext(), Aware_Preferences.DEVICE_ID));
+            data.put("platform", "android");
+            try {
+                PackageInfo package_info = getApplicationContext().getPackageManager().getPackageInfo(getApplicationContext().getPackageName(), 0);
+                data.put("package_name", package_info.packageName);
+                data.put("package_version_code", String.valueOf(package_info.versionCode));
+                data.put("package_version_name", String.valueOf(package_info.versionName));
+            } catch (PackageManager.NameNotFoundException e) {
+                Log.d(Aware.TAG, "Failed to put package info: " + e);
+                e.printStackTrace();
+            }
 
             String protocol = study_url.substring(0, study_url.indexOf(":"));
 

--- a/aware-core/src/main/java/com/aware/utils/StudyUtils.java
+++ b/aware-core/src/main/java/com/aware/utils/StudyUtils.java
@@ -10,6 +10,7 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
 import android.os.AsyncTask;
 import android.support.v4.app.NotificationCompat;
 import android.util.Log;
@@ -58,6 +59,16 @@ public class StudyUtils extends IntentService {
         //Request study settings
         Hashtable<String, String> data = new Hashtable<>();
         data.put(Aware_Preferences.DEVICE_ID, Aware.getSetting(getApplicationContext(), Aware_Preferences.DEVICE_ID));
+        data.put("platform", "android");
+        try {
+            PackageInfo package_info = getApplicationContext().getPackageManager().getPackageInfo(getApplicationContext().getPackageName(), 0);
+            data.put("package_name", package_info.packageName);
+            data.put("package_version_code", String.valueOf(package_info.versionCode));
+            data.put("package_version_name", String.valueOf(package_info.versionName));
+        } catch (PackageManager.NameNotFoundException e) {
+            Log.d(Aware.TAG, "Failed to put package info: " + e);
+            e.printStackTrace();
+        }
 
         String protocol = study_url.substring(0, study_url.indexOf(":"));
         String answer;


### PR DESCRIPTION
This sends some new keys when doing sending usage information or joining a study.  Servers can do what they wish with it.  At least for the usage information, it doesn't exist elsewhere.  I don't know if there is a more canonical location for this information for joining the study, but I don't see it aware_device at least.  Also, this data can be dynamic so maybe it should even be sent each time data is uploaded.

Requesting comments first.

commit msg:

- Include package name, package version name, package version code,
  and platform=android.