### PR TITLE
- Fix: Remove "exported = true" from QueueESM in the manifest. 

### DIFF
--- a/aware-core/src/main/AndroidManifest.xml
+++ b/aware-core/src/main/AndroidManifest.xml
@@ -139,8 +139,7 @@
             android:name="com.aware.ESM"
             android:exported="true" />
         <service
-            android:name="com.aware.ESM$QueueESM"
-            android:exported="true" />
+            android:name="com.aware.ESM$QueueESM" />
         <service
             android:name="com.aware.Installations"
             android:exported="true" />


### PR DESCRIPTION
Only the client needs this class, resulting in double ESM notifications.