### PR TITLE
Allow passing custom study urls to Plugin Downloader.

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -795,10 +795,12 @@ public class Aware extends Service {
      * @param package_name
      * @param is_update
      */
-    public static void downloadPlugin(Context context, String package_name, boolean is_update) {
+    public static void downloadPlugin(Context context, String package_name, String study_custom_url, boolean is_update) {
         Intent pluginIntent = new Intent(context, DownloadPluginService.class);
         pluginIntent.putExtra("package_name", package_name);
         pluginIntent.putExtra("is_update", is_update);
+        if (study_custom_url != null)
+            pluginIntent.putExtra("study_url", study_custom_url);
         context.startService(pluginIntent);
     }
 

--- a/aware-core/src/main/java/com/aware/utils/DownloadPluginService.java
+++ b/aware-core/src/main/java/com/aware/utils/DownloadPluginService.java
@@ -54,9 +54,14 @@ public class DownloadPluginService extends IntentService {
         String package_name = intent.getStringExtra("package_name");
         boolean is_update = intent.getBooleanExtra("is_update", false);
 
-        if( Aware.DEBUG ) Log.d(Aware.TAG, "Trying to download: " + package_name);
-
         String study_url = Aware.getSetting(getApplicationContext(), Aware_Preferences.WEBSERVICE_SERVER);
+        if (intent.hasExtra("study_url"))
+            study_url = intent.getStringExtra("study_url");
+
+
+        if( Aware.DEBUG ) Log.d(Aware.TAG, "Trying to download: " + package_name +" using server: " +study_url);
+
+
         String study_host = study_url.substring(0, study_url.indexOf("/index.php"));
         String protocol = study_url.substring(0, study_url.indexOf(":"));
 

--- a/aware-core/src/main/java/com/aware/utils/StudyUtils.java
+++ b/aware-core/src/main/java/com/aware/utils/StudyUtils.java
@@ -293,7 +293,7 @@ public class StudyUtils extends IntentService {
             if (installed != null) {
                 Aware.startPlugin(context, package_name);
             } else {
-                Aware.downloadPlugin(context, package_name, false);
+                Aware.downloadPlugin(context, package_name, null, false);
             }
         }
 

--- a/aware-phone/src/main/java/com/aware/phone/ui/Aware_Join_Study.java
+++ b/aware-phone/src/main/java/com/aware/phone/ui/Aware_Join_Study.java
@@ -387,7 +387,7 @@ public class Aware_Join_Study extends Aware_Activity {
                 @Override
                 public void onClick(View v) {
                     Toast.makeText(Aware_Join_Study.this, "Installing...", Toast.LENGTH_SHORT).show();
-                    Aware.downloadPlugin(getApplicationContext(), mDataset.get(position).packageName, false);
+                    Aware.downloadPlugin(getApplicationContext(), mDataset.get(position).packageName, study_url, false);
                 }
             });
             if (mDataset.get(position).installed) {

--- a/aware-phone/src/main/java/com/aware/phone/ui/Plugins_Manager.java
+++ b/aware-phone/src/main/java/com/aware/phone/ui/Plugins_Manager.java
@@ -328,7 +328,7 @@ public class Plugins_Manager extends Aware_Activity {
                                     public void onClick(DialogInterface dialog, int which) {
                                         dialog.dismiss();
                                         pkg_title.setText("Updating...");
-                                        Aware.downloadPlugin(getApplicationContext(), package_name, true);
+                                        Aware.downloadPlugin(getApplicationContext(), package_name, null, true);
                                     }
                                 });
                                 builder.create().show();
@@ -353,7 +353,7 @@ public class Plugins_Manager extends Aware_Activity {
                                         dialog.dismiss();
                                         if (!Aware.is_watch(getApplicationContext())) {
                                             Toast.makeText(getApplicationContext(), "Downloading... please wait.", Toast.LENGTH_SHORT).show();
-                                            Aware.downloadPlugin(getApplicationContext(), package_name, false);
+                                            Aware.downloadPlugin(getApplicationContext(), package_name, null, false);
                                         } else {
                                             Toast.makeText(getApplicationContext(), "Please, use the phone to install plugins.", Toast.LENGTH_LONG).show();
                                         }


### PR DESCRIPTION
This allows hosting your own plugins without putting them to the Play store. The relevant parts of the study url will be used to find the right server.