### PR TITLE
- Fix: Memory leak in Wifi service

### DIFF
--- a/aware-core/src/main/java/com/aware/WiFi.java
+++ b/aware-core/src/main/java/com/aware/WiFi.java
@@ -81,7 +81,7 @@ public class WiFi extends Aware_Sensor {
         super.onCreate();
 
         alarmManager = (AlarmManager) getSystemService(ALARM_SERVICE);
-        wifiManager = (WifiManager) getSystemService(WIFI_SERVICE);
+        wifiManager = (WifiManager) this.getApplicationContext().getSystemService(WIFI_SERVICE);
 
         IntentFilter filter = new IntentFilter();
         filter.addAction(WifiManager.SCAN_RESULTS_AVAILABLE_ACTION);
@@ -259,7 +259,7 @@ public class WiFi extends Aware_Sensor {
 
         @Override
         protected void onHandleIntent(Intent intent) {
-            WifiManager wifiManager = (WifiManager) getSystemService(WIFI_SERVICE);
+            WifiManager wifiManager = (WifiManager) this.getApplicationContext().getSystemService(WIFI_SERVICE);
 
             if (intent.getAction().equals(WiFi.ACTION_AWARE_WIFI_REQUEST_SCAN)) {
                 if (wifiManager.isWifiEnabled()) {


### PR DESCRIPTION
Compiling the client using gradlew resulted in the following warning. Changes reflect the compiler's suggestion
```
WiFi.java:84:Error:....
 
WiFi.java:262: Error: The WIFI_SERVICE must be looked up on the Application context or memory will leak on devices < Android N. Try changing  to .getApplicationContext()  [WifiManagerLeak]
            WifiManager wifiManager = (WifiManager) getSystemService(WIFI_SERVICE);
                                                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

   Explanation for issues of type "WifiManagerLeak":
   On versions prior to Android N (24), initializing the WifiManager via
   Context#getSystemService can cause a memory leak if the context is not the
   application context. Change context.getSystemService(...) to
   context.getApplicationContext().getSystemService(...).
```
