### PR TITLE
aware_preferences.xml: Location: clarify location descriptions.

### DIFF
--- a/aware-core/src/main/res/xml/aware_preferences.xml
+++ b/aware-core/src/main/res/xml/aware_preferences.xml
@@ -308,7 +308,7 @@
                 android:key="frequency_location_gps"
                 android:persistent="true"
                 android:summary="X seconds. (0 = always on)"
-                android:title="GPS update frequency" />
+                android:title="Minimum GPS update frequency" />
 
             <EditTextPreference
                 android:defaultValue="150"
@@ -317,7 +317,7 @@
                 android:key="min_location_gps_accuracy"
                 android:persistent="true"
                 android:summary="X meters. (0 = always on)"
-                android:title="Desired GPS accuracy" />
+                android:title="Movement threshold for GPS updates" />
 
             <CheckBoxPreference
                 android:defaultValue="false"
@@ -333,7 +333,7 @@
                 android:key="frequency_location_network"
                 android:persistent="true"
                 android:summary="X seconds. (0 = always on)"
-                android:title="Triangulation update frequency" />
+                android:title="Minimum triangulation update frequency" />
 
             <EditTextPreference
                 android:defaultValue="1500"
@@ -342,7 +342,7 @@
                 android:key="min_location_network_accuracy"
                 android:persistent="true"
                 android:summary="X meters. (0 = always on)"
-                android:title="Desired triangulation accuracy" />
+                android:title="Movement threshold for triangulation updates" />
 
             <EditTextPreference
                 android:defaultValue="300"


### PR DESCRIPTION
Hi,

This clarifies some of the location wordings.  Last year I spent several hours trying to figure out why locations wasn't giving any values before I found out that accuracy meant a distance threshold for sending new values.  This came up today again, so I made this quick patch.

======

- The frequency/accuracy do not mean exactly what they imply.  They
  are sent to Android and it tries to make a clever schedule giving
  updates.
- Frequency: location updates are given no more frequently than the
  given value.  It can be less if Android sees no reason to update
  again (see accuracy below).
- Accuracy: if the device has not moved more than this amount, then do
  not give location updates.
- There are changes to functionality of Aware, only explanation in UI.