### PR TITLE
Don't clear aware_studies table when webservice_remove_data=true

### DIFF
--- a/aware-core/src/main/java/com/aware/utils/WebserviceHelper.java
+++ b/aware-core/src/main/java/com/aware/utils/WebserviceHelper.java
@@ -80,6 +80,7 @@ public class WebserviceHelper extends Service {
 
     private static final Map<String, Boolean> SYNCED_TABLES = Collections.synchronizedMap(new HashMap<String, Boolean>());
     private static ArrayList<String> highFrequencySensors = new ArrayList<>();
+    private static final ArrayList<String> dontClearSensors = new ArrayList<>();
 
     // Handler that receives messages from the thread
     private final class SyncQueue extends Handler {
@@ -123,6 +124,8 @@ public class WebserviceHelper extends Service {
         highFrequencySensors.add("rotation");
         highFrequencySensors.add("temperature");
         highFrequencySensors.add("proximity");
+
+        dontClearSensors.add("aware_studies");
 
         notificationID = 0;
 
@@ -613,6 +616,14 @@ public class WebserviceHelper extends Service {
                 context_data.close(); //clear phone's memory immediately
 
                 lastSynced = rows.getJSONObject(rows.length() - 1).getLong("timestamp"); //last record to be synced
+                // For some tables, we must not clear everything.  Leave one row of these tables.
+                if (dontClearSensors.contains(DATABASE_TABLE)) {
+                    if (rows.length() >= 2) {
+                        lastSynced = rows.getJSONObject(rows.length() - 2).getLong("timestamp"); //last record to be synced
+                    } else {
+                        lastSynced = 0;
+                    }
+                }
 
                 Hashtable<String, String> request = new Hashtable<>();
                 request.put(Aware_Preferences.DEVICE_ID, DEVICE_ID);


### PR DESCRIPTION
Hi,

This goes along with "webservice_remove_data", which makes Aware clear all data from the tables.  Aware was changed to use the last row of aware_studies to view study info.  This change prevents clearing that table (it only keeps the last line), and could be extended to others too.  However, I don't know if this is the best way to do this.  It hard-codes table names into another file instead of using the provider.  Maybe there's a better way that can extend to other plugins?

I don't know if others want to use "webservice_remove_data", if not then I'm fine with maintaining this patch in our own branch.

====
Don't clear aware_studies table when webservice_remove_data=true

- The aware_studies table is special, because it is needed in order to
  get the study info.  If it is cleared, you can't see the current
  study or even leave studies.
- Add a fix which prevents the most recent row from being removed.