### PR TITLE
Location save all

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware_Preferences.java
+++ b/aware-core/src/main/java/com/aware/Aware_Preferences.java
@@ -209,6 +209,14 @@ public class Aware_Preferences {
     public static final String LOCATION_GEOFENCE = "location_geofence";
 
     /**
+     * Save all locations.  All locations given to the location service will be saved,
+     * without applying any logic to find the currently most accurate locations.
+     * This makes for a slightly more complicated analysis later on, but more data
+     * to work with.
+     */
+    public static final String LOCATION_SAVE_ALL = "location_save_all";
+
+    /**
      * Activate/deactivate light sensor log (boolean)
      */
     public static final String STATUS_LIGHT = "status_light";

--- a/aware-core/src/main/res/xml/aware_preferences.xml
+++ b/aware-core/src/main/res/xml/aware_preferences.xml
@@ -352,6 +352,14 @@
                 android:persistent="true"
                 android:summary="Expire after X seconds"
                 android:title="Location fix lifetime" />
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:dependency="status_location_gps"
+                android:key="location_save_all"
+                android:persistent="true"
+                android:summary="Don't use heurestics to only record best locations"
+                android:title="Save all locations" />
         </PreferenceScreen>
         <PreferenceScreen
             android:icon="@drawable/ic_action_light"


### PR DESCRIPTION
This adds a new configuration option "location_save_all".  When this is set, every single location that android produces gets saved to the log, even if it is within the expiration time, is less accurate, etc.  This gives the most complete picture for future analysis, even if it is slightly less useful for real-time analysis by other apps.

Note some of the code was split into another function save_location, and the diff below is a bit confusing because of this.

This is *probably* safe to merge, but I am still testing it - I will give final confirmation in a day or two.