### PR TITLE
Low frequency sensor values

### DIFF
--- a/aware-core/src/main/res/values/arrays.xml
+++ b/aware-core/src/main/res/values/arrays.xml
@@ -15,28 +15,34 @@
         <item >Always</item>
     </string-array>
     <string-array name="frequency_values">
+        <item>1000000</item>
         <item>200000</item>
         <item>60000</item>
         <item>20000</item>
         <item>0</item>
     </string-array>
     <string-array name="frequency_readable">
+        <item>Very slow (1000ms)</item>
         <item>Slow (200ms)</item>
         <item>Normal (60ms)</item>
         <item>Fast (20ms)</item>
         <item>Fastest (0ms)</item>
     </string-array>
     <string-array name="low_frequency_values">
-        <item>3600000000</item>
+        <item>900000000</item>
         <item>60000000</item>
         <item>1000000</item>
+        <item>200000</item>
+        <item>60000</item>
         <item>20000</item>
         <item>0</item>
     </string-array>
     <string-array name="low_frequency_readable">
-        <item>Slow (1hour)</item>
-        <item>Normal (1min)</item>
-        <item>Faster (1s)</item>
+        <item>15 minutes (900s)</item>
+        <item>1 minute (60s)</item>
+        <item>Very slow (1s)</item>
+        <item>Slow (200ms)</item>
+        <item>Normal (60ms)</item>
         <item>Fast (20ms)</item>
         <item>Fastest (0ms)</item>
     </string-array>

--- a/aware-core/src/main/res/values/arrays.xml
+++ b/aware-core/src/main/res/values/arrays.xml
@@ -21,9 +21,23 @@
         <item>0</item>
     </string-array>
     <string-array name="frequency_readable">
-        <item>Slow</item>
-        <item>Normal</item>
-        <item>Fast</item>
-        <item>Fastest</item>
+        <item>Slow (200ms)</item>
+        <item>Normal (60ms)</item>
+        <item>Fast (20ms)</item>
+        <item>Fastest (0ms)</item>
+    </string-array>
+    <string-array name="low_frequency_values">
+        <item>3600000000</item>
+        <item>60000000</item>
+        <item>1000000</item>
+        <item>20000</item>
+        <item>0</item>
+    </string-array>
+    <string-array name="low_frequency_readable">
+        <item>Slow (1hour)</item>
+        <item>Normal (1min)</item>
+        <item>Faster (1s)</item>
+        <item>Fast (20ms)</item>
+        <item>Fastest (0ms)</item>
     </string-array>
 </resources>

--- a/aware-core/src/main/res/xml/aware_preferences.xml
+++ b/aware-core/src/main/res/xml/aware_preferences.xml
@@ -627,8 +627,8 @@
             <ListPreference
                 android:defaultValue="200000"
                 android:dependency="status_temperature"
-                android:entries="@array/frequency_readable"
-                android:entryValues="@array/frequency_values"
+                android:entries="@array/low_frequency_readable"
+                android:entryValues="@array/low_frequency_values"
                 android:key="frequency_temperature"
                 android:persistent="true"
                 android:summary="%s"

--- a/aware-core/src/main/res/xml/aware_preferences.xml
+++ b/aware-core/src/main/res/xml/aware_preferences.xml
@@ -135,8 +135,8 @@
             <ListPreference
                 android:defaultValue="200000"
                 android:dependency="status_barometer"
-                android:entries="@array/frequency_readable"
-                android:entryValues="@array/frequency_values"
+                android:entries="@array/low_frequency_readable"
+                android:entryValues="@array/low_frequency_values"
                 android:key="frequency_barometer"
                 android:persistent="true"
                 android:summary="%s"
@@ -368,8 +368,8 @@
             <ListPreference
                 android:defaultValue="200000"
                 android:dependency="status_light"
-                android:entries="@array/frequency_readable"
-                android:entryValues="@array/frequency_values"
+                android:entries="@array/low_frequency_readable"
+                android:entryValues="@array/low_frequency_values"
                 android:key="frequency_light"
                 android:persistent="true"
                 android:summary="%s"
@@ -535,8 +535,8 @@
             <ListPreference
                 android:defaultValue="200000"
                 android:dependency="status_proximity"
-                android:entries="@array/frequency_readable"
-                android:entryValues="@array/frequency_values"
+                android:entries="@array/low_frequency_readable"
+                android:entryValues="@array/low_frequency_values"
                 android:key="frequency_proximity"
                 android:persistent="true"
                 android:summary="%s"


### PR DESCRIPTION
Hi,

This adjusts the default selectable frequency values.  It adds one thing more slower to all sensors, and for barometer, light, temperature, and proximity provides some much lower values also.  This is most useful with the enforce_frequency PR, since Android can still give points more frequently than what is requested, so just setting a lower value doesn't directly reduce the data.

It would be best to think about what values are most useful before merging.  FYI: we also use a medical-grade wrist-worn activity tracker, and this collects a single accelerometer data point every 30 seconds.  So slower values are not entirely unheard of.