### PR TITLE
intent-filter: Add a browseable intent filter: aware-register+https://

### DIFF
--- a/aware-phone/src/main/AndroidManifest.xml
+++ b/aware-phone/src/main/AndroidManifest.xml
@@ -121,6 +121,13 @@
             android:label="Join study"
             android:launchMode="singleTop"
             android:theme="@style/Theme.Aware">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="aware-register+http" />
+                <data android:scheme="aware-register+https" />
+            </intent-filter>
             <meta-data
                 android:name="android.support.PARENT_ACTIVITY"
                 android:value="com.aware.phone.Aware_Client" />


### PR DESCRIPTION
(not currently mergeable, for discussion!)

Hi,

This demonstrates the joining of studies via a URI handler, as mentioned in #53.  Using this, one can click a link "aware-register+https://aware.server.com/path/to/study", and direct it to the app.  The "aware-register+" is stripped off from the scheme, and then this URL is used for joining.  So, for example, you can email a URI to someone and they can join, or they can log in to the study portal on their phone and click a URL.

The principle works, but there are problems.  The URL is handled by `ui.Aware_Join_Study` activity, which then calls `Aware.joinStudy` with the URL.  However, the Aware_Join_Study activity is left uninitialized and crashes once started again, and `Aware.joinStudy` doesn't present the in-app verification like QR code scanning does.

I think that in order to make this work properly, there should be a) a separate activity for joining by URL or other intents, b) separation of the the `StudyData` class in `Aware_QRCode`, so that it can be used by multiple sources. (maybe even add to aware-core?)  These are larger changes than I am comfortable with right now, since there are probably deeper design decisions in here.  Do you have any advice?  if you can get it ready,  I can finalize and test.

Thanks,
- Richard

-----

- Using this intent-filter, one can click on a url like
  "aware-register+https://server.com/path/to/study" and things will
  automatically join.
- This does NOT work yet, it should be handled identically to QR code
  scanning but currently that isn't possible.