### PR TITLE
Passive location

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -2221,7 +2221,9 @@ public class Aware extends Service {
             startInstallations(context);
         } else stopInstallations(context);
 
-        if (Aware.getSetting(context, Aware_Preferences.STATUS_LOCATION_GPS).equals("true") || Aware.getSetting(context, Aware_Preferences.STATUS_LOCATION_NETWORK).equals("true")) {
+        if (Aware.getSetting(context, Aware_Preferences.STATUS_LOCATION_GPS).equals("true")
+                || Aware.getSetting(context, Aware_Preferences.STATUS_LOCATION_NETWORK).equals("true")
+                || Aware.getSetting(context, Aware_Preferences.STATUS_LOCATION_PASSIVE).equals("true")) {
             startLocations(context);
         } else stopLocations(context);
 
@@ -2718,7 +2720,9 @@ public class Aware extends Service {
      */
     public static void stopLocations(Context context) {
         if (context == null) return;
-        if (!Aware.getSetting(context, Aware_Preferences.STATUS_LOCATION_GPS).equals("true") && !Aware.getSetting(context, Aware_Preferences.STATUS_LOCATION_NETWORK).equals("true")) {
+        if (!Aware.getSetting(context, Aware_Preferences.STATUS_LOCATION_GPS).equals("true")
+                && !Aware.getSetting(context, Aware_Preferences.STATUS_LOCATION_NETWORK).equals("true")
+                && !Aware.getSetting(context, Aware_Preferences.STATUS_LOCATION_PASSIVE).equals("true")) {
             if (locationsSrv != null) context.stopService(locationsSrv);
         }
     }

--- a/aware-core/src/main/java/com/aware/Aware_Preferences.java
+++ b/aware-core/src/main/java/com/aware/Aware_Preferences.java
@@ -209,6 +209,14 @@ public class Aware_Preferences {
     public static final String LOCATION_GEOFENCE = "location_geofence";
 
     /**
+     * Save all locations.  All locations given to the location service will be saved,
+     * without applying any logic to find the currently most accurate locations.
+     * This makes for a slightly more complicated analysis later on, but more data
+     * to work with.
+     */
+    public static final String LOCATION_SAVE_ALL = "location_save_all";
+
+    /**
      * Activate/deactivate light sensor log (boolean)
      */
     public static final String STATUS_LIGHT = "status_light";

--- a/aware-core/src/main/java/com/aware/Aware_Preferences.java
+++ b/aware-core/src/main/java/com/aware/Aware_Preferences.java
@@ -216,6 +216,14 @@ public class Aware_Preferences {
      */
     public static final String LOCATION_SAVE_ALL = "location_save_all";
 
+
+    /**
+     * Activate/deactivate passive location log (boolean).  This does not turn on GPS/network
+     * location tracking, but if any other application turns on location requests, Aware will
+     * receive the locations too, with little battery overhead.
+     */
+    public static final String STATUS_LOCATION_PASSIVE = "status_location_passive";
+
     /**
      * Activate/deactivate light sensor log (boolean)
      */

--- a/aware-core/src/main/res/xml/aware_preferences.xml
+++ b/aware-core/src/main/res/xml/aware_preferences.xml
@@ -352,6 +352,14 @@
                 android:persistent="true"
                 android:summary="Expire after X seconds"
                 android:title="Location fix lifetime" />
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:dependency="status_location_gps"
+                android:key="location_save_all"
+                android:persistent="true"
+                android:summary="Don't use heurestics to only record best locations"
+                android:title="Save all locations" />
         </PreferenceScreen>
         <PreferenceScreen
             android:icon="@drawable/ic_action_light"

--- a/aware-core/src/main/res/xml/aware_preferences.xml
+++ b/aware-core/src/main/res/xml/aware_preferences.xml
@@ -307,7 +307,7 @@
                 android:inputType="number"
                 android:key="frequency_location_gps"
                 android:persistent="true"
-                android:summary="X seconds. (0 = always on)"
+                android:summary="Seconds (0 = always on)"
                 android:title="Minimum GPS update frequency" />
 
             <EditTextPreference
@@ -316,7 +316,7 @@
                 android:inputType="number"
                 android:key="min_location_gps_accuracy"
                 android:persistent="true"
-                android:summary="X meters. (0 = always on)"
+                android:summary="Meters (0 = always on)"
                 android:title="Movement threshold for GPS updates" />
 
             <CheckBoxPreference
@@ -332,7 +332,7 @@
                 android:inputType="number"
                 android:key="frequency_location_network"
                 android:persistent="true"
-                android:summary="X seconds. (0 = always on)"
+                android:summary="Seconds (0 = always on)"
                 android:title="Minimum triangulation update frequency" />
 
             <EditTextPreference
@@ -341,12 +341,18 @@
                 android:inputType="number"
                 android:key="min_location_network_accuracy"
                 android:persistent="true"
-                android:summary="X meters. (0 = always on)"
+                android:summary="Meters (0 = always on)"
                 android:title="Movement threshold for triangulation updates" />
+
+            <CheckBoxPreference
+                android:defaultValue="false"
+                android:key="status_location_passive"
+                android:persistent="true"
+                android:summary="Don't fetch locations, but use locations if other apps request them."
+                android:title="Passive location provider" />
 
             <EditTextPreference
                 android:defaultValue="300"
-                android:dependency="status_location_gps"
                 android:inputType="number"
                 android:key="location_expiration_time"
                 android:persistent="true"
@@ -355,7 +361,6 @@
 
             <CheckBoxPreference
                 android:defaultValue="false"
-                android:dependency="status_location_gps"
                 android:key="location_save_all"
                 android:persistent="true"
                 android:summary="Don't use heurestics to only record best locations"


### PR DESCRIPTION
Note: this depends (is derived from) on PR #164 (location_save_all), don't merge until that is done... and until that's done, diff will be bad.  
Note: don't merge yet, still being tested!

This adds support for the passive location provider, which doesn't turn any sensors on, but will use locations which are requested by other applications.  The semantics and config options could still use some thinking.

This would solve #168.

Thanks,
- Richard

-----

 - The passive location provider does not turn on GPS or triangulation,
  but will give you the locations if any other apps decide to turn
  these sensors on.
- Currently you don't set the frequency/movement threshold of this
  sensor, and it registers the listener with a period of 60 seconds.
  Actual frequency will be determined by whatever app is requesting
  the locations.
- Various other cosmetic changes in the settings.
- Locations_save_all and location_expiration_time are made to not
  depend on status_location_gps.  With three providers, it doesn't
  make sense to have them only active if gps is on.  The best option
  would be something with a three-way OR dependency, on the three
  providers.