### PR TITLE
Ssl handling

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -1462,7 +1462,7 @@ public class Aware extends Service {
             String request;
             if (protocol.equals("https")) {
 
-                SSLManager.downloadCertificate(getApplicationContext(), study_uri.getHost(), true);
+                SSLManager.handleUrl(getApplicationContext(), full_url, true);
 
 //                try {
 //                    Intent installHTTPS = KeyChain.createInstallIntent();

--- a/aware-core/src/main/java/com/aware/utils/SSLManager.java
+++ b/aware-core/src/main/java/com/aware/utils/SSLManager.java
@@ -79,7 +79,8 @@ public class SSLManager {
             } else {
                 try {
                     URL javaURL = new URL(url);
-                    if (!hasCertificate(context, hostname) && (getCertificateExpiration(javaURL) != null && System.currentTimeMillis() >= getCertificateExpiration(javaURL).getTime())) {
+                    Date certificateExpiration = getCertificateExpiration(javaURL);
+                    if (!hasCertificate(context, hostname) && (certificateExpiration != null && System.currentTimeMillis() >= certificateExpiration.getTime())) {
                         if (Aware.DEBUG)
                             Log.d(Aware.TAG, "Certificates: Downloading certificate: " + hostname);
 

--- a/aware-core/src/main/java/com/aware/utils/StudyUtils.java
+++ b/aware-core/src/main/java/com/aware/utils/StudyUtils.java
@@ -74,7 +74,7 @@ public class StudyUtils extends IntentService {
 //            SSLManager.handleUrl(getApplicationContext(), full_url, true);
 
             //Note: Joining a study always downloads the certificate
-            SSLManager.downloadCertificate(getApplicationContext(), study_uri.getHost(), true);
+            SSLManager.handleUrl(getApplicationContext(), full_url, true);
 
 //            try {
 //                Intent installHTTPS = KeyChain.createInstallIntent();

--- a/aware-phone/src/main/java/com/aware/phone/Aware_Client.java
+++ b/aware-phone/src/main/java/com/aware/phone/Aware_Client.java
@@ -462,8 +462,7 @@ public class Aware_Client extends Aware_Activity implements SharedPreferences.On
         protected Boolean doInBackground(Void... params) {
             // Download the certificate, and block since we are already running in background
             // and we need the certificate immediately.
-            Uri server_url = Uri.parse("https://api.awareframework.com/index.php");
-            SSLManager.downloadCertificate(getApplicationContext(), server_url.getHost(), true);
+            SSLManager.handleUrl(getApplicationContext(), "https://api.awareframework.com/index.php", true);
 
             //Ping AWARE's server with getApplicationContext() device's information for framework's statistics log
             Hashtable<String, String> device_ping = new Hashtable<>();

--- a/aware-phone/src/main/java/com/aware/phone/ui/Aware_QRCode.java
+++ b/aware-phone/src/main/java/com/aware/phone/ui/Aware_QRCode.java
@@ -134,7 +134,7 @@ public class Aware_QRCode extends Aware_Activity implements ZBarScannerView.Resu
             if (protocol.equals("https")) {
 
                 //Note: Joining a study always downloads the certificate.
-                SSLManager.downloadCertificate(getApplicationContext(), study_uri.getHost(), true);
+                SSLManager.handleUrl(getApplicationContext(), study_url, true);
 
 //                try {
 //                    Intent installHTTPS = KeyChain.createInstallIntent();


### PR DESCRIPTION
Hi,

Some things about SSL handling.

- in `handleUrl`, don't run `getCertificateExpiration` twice in a row.  Cache the result.  This accesses the network so better to do this.
- Change some occurrences of `downloadCertificate` to `handleUrl`.  I did this in a previous PR, but it seems to have been lost.  the purpose is that `handleUrl` always gets the full `webservice_server` url (including any query arguments, if they are any) and handles whatever our cert updating policy is.  The check using `getCertificateExpiration` is in here, for example.  This can use the `key_strategy` option (as for as I know, I'm the only one that does this...)  By default, with no other options, it calls `downloadCertificate` (after the new expiration check), which was the previous default behavior.
- Note: I notice that the `getCertificateExpiration` connects to network to see expiration.  If the certificate on the server is updated, won't it be non-expired and thus not update?  I'm still trying to think of best way to do this, and so far all I can think of is domain name versioning.

Status of PR: Written earlier in the week and tested several times.