### PR TITLE
WebserviceHelper: don't re-upload if WEBSERVICE_SIMPLE and dontClearT…

### DIFF
--- a/aware-core/src/main/java/com/aware/utils/WebserviceHelper.java
+++ b/aware-core/src/main/java/com/aware/utils/WebserviceHelper.java
@@ -409,7 +409,7 @@ public class WebserviceHelper extends Service {
             // Only if WEBSERVICE_REMOVE_DATA is true can we safely do this, and
             // we also require WEBSERVICE_SIMPLE so that we can remove data while
             // still having safe commits.
-            if (!(WEBSERVICE_SIMPLE && WEBSERVICE_REMOVE_DATA)) {
+            if (!(WEBSERVICE_SIMPLE && WEBSERVICE_REMOVE_DATA) || dontClearSensors.contains(DATABASE_TABLE)) {
                 // Normal AWARE API always gets here.
                 if (protocol.equals("https")) {
                     try {


### PR DESCRIPTION
don't re-upload if WEBSERVICE_SIMPLE and dontClearTables

- webservice_simple, by design, uploads all data present in the tables
  and removes all data afterwards.  There is no check for the latest
  data the server has.
- dontClearTables is used (currently just for aware_studies), the
  table is not cleared.
- Combined, there is a problem: the same data gets uploaded again and
  again.
- This patch makes the latest-on-server check be used for
  dontClearTables, which restores the expected behavior at the cost of
  an extra remote call every sync.