### PR TITLE
Add option for storing databases in internal storage (default disabled)

### DIFF
--- a/aware-core/src/main/java/com/aware/utils/DatabaseHelper.java
+++ b/aware-core/src/main/java/com/aware/utils/DatabaseHelper.java
@@ -226,10 +226,17 @@ public class DatabaseHelper extends SQLiteOpenHelper {
     private synchronized SQLiteDatabase getDatabaseFile() {
         try {
             File aware_folder;
-            if (!mContext.getResources().getBoolean(R.bool.standalone)) {
-                aware_folder = new File(Environment.getExternalStoragePublicDirectory("AWARE").toString()); // sdcard/AWARE/ (shareable, does not delete when uninstalling)
+            if (mContext.getResources().getBoolean(R.bool.internalstorage)) {
+                // Internal storage.  This is not acceassible to any other apps and is removed once
+                // app is uninstalled.  Plugins can't use it.  Hard-coded to off, only change if
+                // you know what you are doing.  Beware!
+                aware_folder = mContext.getFilesDir();
+            } else if (!mContext.getResources().getBoolean(R.bool.standalone)) {
+                // sdcard/AWARE/ (shareable, does not delete when uninstalling)
+                aware_folder = new File(Environment.getExternalStoragePublicDirectory("AWARE").toString());
             } else {
-                aware_folder = new File(ContextCompat.getExternalFilesDirs(mContext, null)[0] + "/AWARE"); // sdcard/Android/<app_package_name>/AWARE/ (not shareable, deletes when uninstalling package)
+                // sdcard/Android/<app_package_name>/AWARE/ (not shareable, deletes when uninstalling package)
+                aware_folder = new File(ContextCompat.getExternalFilesDirs(mContext, null)[0] + "/AWARE");
             }
 
             if (!aware_folder.exists()) {

--- a/aware-core/src/main/java/com/aware/utils/SSLManager.java
+++ b/aware-core/src/main/java/com/aware/utils/SSLManager.java
@@ -149,7 +149,9 @@ public class SSLManager {
         } else cert_host = hostname;
 
         File root_folder;
-        if (!context.getApplicationContext().getResources().getBoolean(R.bool.standalone)) {
+        if (context.getApplicationContext().getResources().getBoolean(R.bool.internalstorage)) {
+            root_folder = new File(context.getFilesDir(), "/credentials/" + hostname);
+        } else if (!context.getApplicationContext().getResources().getBoolean(R.bool.standalone)) {
             root_folder = new File(Environment.getExternalStoragePublicDirectory("AWARE"), "/credentials/" + hostname); // sdcard/AWARE/ (shareable, does not delete when uninstalling)
         } else {
             root_folder = new File(ContextCompat.getExternalFilesDirs(context, null)[0], "/AWARE/credentials/" + hostname); // sdcard/Android/<app_package_name>/AWARE/ (not shareable, deletes when uninstalling package)
@@ -259,7 +261,9 @@ public class SSLManager {
         if (hostname == null || hostname.length() == 0) return false;
 
         File root_folder;
-        if (!context.getResources().getBoolean(R.bool.standalone)) {
+        if (context.getResources().getBoolean(R.bool.internalstorage)) {
+            root_folder = new File(context.getFilesDir() + "/credentials");
+        } else if (!context.getResources().getBoolean(R.bool.standalone)) {
             root_folder = new File(Environment.getExternalStoragePublicDirectory("AWARE") + "/credentials"); // sdcard/AWARE/ (shareable, does not delete when uninstalling)
         } else {
             root_folder = new File(ContextCompat.getExternalFilesDirs(context, null)[0] + "/AWARE/credentials"); // sdcard/Android/<app_package_name>/AWARE/ (not shareable, deletes when uninstalling package)
@@ -284,7 +288,9 @@ public class SSLManager {
         if (hostname == null || hostname.length() == 0) return;
 
         File root_folder;
-        if (!context.getResources().getBoolean(R.bool.standalone)) {
+        if (context.getResources().getBoolean(R.bool.internalstorage)) {
+            root_folder = new File(context.getFilesDir() + "/credentials");
+        } else if (!context.getResources().getBoolean(R.bool.standalone)) {
             root_folder = new File(Environment.getExternalStoragePublicDirectory("AWARE") + "/credentials"); // sdcard/AWARE/ (shareable, does not delete when uninstalling)
         } else {
             root_folder = new File(ContextCompat.getExternalFilesDirs(context, null)[0] + "/AWARE/credentials"); // sdcard/Android/<app_package_name>/AWARE/ (not shareable, deletes when uninstalling package)
@@ -326,7 +332,9 @@ public class SSLManager {
         if (hostname == null || hostname.length() == 0) return null;
 
         File root_folder;
-        if (!context.getResources().getBoolean(R.bool.standalone)) {
+        if (context.getResources().getBoolean(R.bool.internalstorage)) {
+            root_folder = new File(context.getFilesDir() + "/credentials");
+        } else if (!context.getResources().getBoolean(R.bool.standalone)) {
             root_folder = new File(Environment.getExternalStoragePublicDirectory("AWARE") + "/credentials"); // sdcard/AWARE/ (shareable, does not delete when uninstalling)
         } else {
             root_folder = new File(ContextCompat.getExternalFilesDirs(context, null)[0] + "/AWARE/credentials"); // sdcard/Android/<app_package_name>/AWARE/ (not shareable, deletes when uninstalling package)
@@ -359,7 +367,9 @@ public class SSLManager {
         if (server == null || server.length() == 0) return null;
 
         File root_folder;
-        if (!context.getResources().getBoolean(R.bool.standalone)) {
+        if (context.getResources().getBoolean(R.bool.internalstorage)) {
+            root_folder = new File(context.getFilesDir() + "/credentials");
+        } else if (!context.getResources().getBoolean(R.bool.standalone)) {
             root_folder = new File(Environment.getExternalStoragePublicDirectory("AWARE") + "/credentials"); // sdcard/AWARE/ (shareable, does not delete when uninstalling)
         } else {
             root_folder = new File(ContextCompat.getExternalFilesDirs(context, null)[0] + "/AWARE/credentials"); // sdcard/Android/<app_package_name>/AWARE/ (not shareable, deletes when uninstalling package)

--- a/aware-core/src/main/res/values/bools.xml
+++ b/aware-core/src/main/res/values/bools.xml
@@ -2,4 +2,5 @@
 <resources>
     <item name="accessibility_access" type="bool" format="boolean">false</item>
     <item name="standalone" type="bool" format="boolean">false</item>
+    <item name="internalstorage" type="bool" format="boolean">false</item>
 </resources>


### PR DESCRIPTION
In this PR, we add a resources option (bools.xml) which can allow data to be stored in internal storage, instead of external public.  This is in parallel to the recent "standalone" option, but works in less places.  It would only be used for specific projects with standalone apps. 

- This, like the `standalone` option, allows one to change where the
  data is stored.  This puts data into internal storage.
- This should only be used if you know what you are doing.  It is
  hardcoded to off.  Data won't be accessible to you, so debugging is
  harder.
- This won't work with plugins.  There are probable other corner
  cases, too.
- You can access the data if you backup the app.  Clearly this is only
  for debugging.  For a hint at extracting the backup, see
  https://android.stackexchange.com/a/78183