### PR TITLE
Add more advanced hashing options (phone, MACs, network names)

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware_Preferences.java
+++ b/aware-core/src/main/java/com/aware/Aware_Preferences.java
@@ -543,7 +543,8 @@ public class Aware_Preferences {
     public static final String HASH_SALT = "hash_salt";
 
     /**
-     * hash function salt.  If "device_id", then salt with this device's device_id.
+     * hash function phone.  If "device_id", then salt with this device's device_id.
+     * This can be a hash name or a hash program
      */
     public static final String HASH_FUNCTION_PHONE = "hash_function_phone";
 

--- a/aware-core/src/main/java/com/aware/Aware_Preferences.java
+++ b/aware-core/src/main/java/com/aware/Aware_Preferences.java
@@ -549,6 +549,19 @@ public class Aware_Preferences {
     public static final String HASH_FUNCTION_PHONE = "hash_function_phone";
 
     /**
+     * hash function MAC.  Do we hash MAC addresses?
+     * blank=unhashed, non-blank=run this hash program (see Encrypter).
+     */
+    public static final String HASH_FUNCTION_MAC = "hash_function_mac";
+
+
+    /**
+     * hash function for SSID/network names/bluetooth names.
+     * blank=unhashed, non-blank=run this hash program.
+     */
+    public static final String HASH_FUNCTION_SSID = "hash_function_ssid";
+
+    /**
      * Activate/deactivate significant motion sensing
      */
     public static final String STATUS_SIGNIFICANT_MOTION = "status_significant_motion";

--- a/aware-core/src/main/java/com/aware/Bluetooth.java
+++ b/aware-core/src/main/java/com/aware/Bluetooth.java
@@ -38,6 +38,7 @@ import com.aware.providers.Bluetooth_Provider.Bluetooth_Data;
 import com.aware.providers.Bluetooth_Provider.Bluetooth_Sensor;
 import com.aware.ui.PermissionsHandler;
 import com.aware.utils.Aware_Sensor;
+import com.aware.utils.Encrypter;
 
 /**
  * Bluetooth Module. For now, scans and returns surrounding bluetooth devices and RSSI dB values.
@@ -229,8 +230,8 @@ public class Bluetooth extends Aware_Sensor {
                 ContentValues rowData = new ContentValues();
                 rowData.put(Bluetooth_Data.DEVICE_ID, Aware.getSetting(context, Aware_Preferences.DEVICE_ID));
                 rowData.put(Bluetooth_Data.TIMESTAMP, System.currentTimeMillis());
-                rowData.put(Bluetooth_Data.BT_ADDRESS, btDevice.getAddress());
-                rowData.put(Bluetooth_Data.BT_NAME, ((btDevice.getName()!=null)?btDevice.getName():""));
+                rowData.put(Bluetooth_Data.BT_ADDRESS, Encrypter.hashMac(context, btDevice.getAddress()));
+                rowData.put(Bluetooth_Data.BT_NAME, Encrypter.hashSsid(context, btDevice.getName()));
                 rowData.put(Bluetooth_Data.BT_RSSI, btDeviceRSSI);
                 rowData.put(Bluetooth_Data.BT_LABEL, scanTimestamp);
 
@@ -310,8 +311,8 @@ public class Bluetooth extends Aware_Sensor {
             ContentValues rowData = new ContentValues();
             rowData.put(Bluetooth_Sensor.TIMESTAMP, System.currentTimeMillis());
             rowData.put(Bluetooth_Sensor.DEVICE_ID, Aware.getSetting(getApplicationContext(), Aware_Preferences.DEVICE_ID));
-            rowData.put(Bluetooth_Sensor.BT_ADDRESS, btAdapter.getAddress());
-            rowData.put(Bluetooth_Sensor.BT_NAME, ((btAdapter.getName()!=null)?btAdapter.getName():""));
+            rowData.put(Bluetooth_Sensor.BT_ADDRESS, Encrypter.hashMac(getApplicationContext(), btAdapter.getAddress()));
+            rowData.put(Bluetooth_Sensor.BT_NAME, Encrypter.hashSsid(getApplicationContext(), btAdapter.getName()));
 
             getContentResolver().insert(Bluetooth_Sensor.CONTENT_URI, rowData);
 

--- a/aware-core/src/main/java/com/aware/WiFi.java
+++ b/aware-core/src/main/java/com/aware/WiFi.java
@@ -29,6 +29,7 @@ import com.aware.providers.WiFi_Provider.WiFi_Data;
 import com.aware.providers.WiFi_Provider.WiFi_Sensor;
 import com.aware.ui.PermissionsHandler;
 import com.aware.utils.Aware_Sensor;
+import com.aware.utils.Encrypter;
 
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -171,9 +172,9 @@ public class WiFi extends Aware_Sensor {
             ContentValues rowData = new ContentValues();
             rowData.put(WiFi_Sensor.DEVICE_ID, Aware.getSetting(mContext, Aware_Preferences.DEVICE_ID));
             rowData.put(WiFi_Sensor.TIMESTAMP, System.currentTimeMillis());
-            rowData.put(WiFi_Sensor.MAC_ADDRESS, mWifi.getMacAddress());
-            rowData.put(WiFi_Sensor.BSSID, ((mWifi.getBSSID() != null) ? mWifi.getBSSID() : ""));
-            rowData.put(WiFi_Sensor.SSID, ((mWifi.getSSID() != null) ? mWifi.getSSID() : ""));
+            rowData.put(WiFi_Sensor.MAC_ADDRESS, Encrypter.hashMac(mContext, mWifi.getMacAddress()));
+            rowData.put(WiFi_Sensor.BSSID, Encrypter.hashMac(mContext, mWifi.getBSSID()));
+            rowData.put(WiFi_Sensor.SSID, Encrypter.hashSsid(mContext, mWifi.getSSID()));
 
             try {
                 mContext.getContentResolver().insert(WiFi_Sensor.CONTENT_URI, rowData);
@@ -215,8 +216,8 @@ public class WiFi extends Aware_Sensor {
                 ContentValues rowData = new ContentValues();
                 rowData.put(WiFi_Data.DEVICE_ID, Aware.getSetting(mContext, Aware_Preferences.DEVICE_ID));
                 rowData.put(WiFi_Data.TIMESTAMP, currentScan);
-                rowData.put(WiFi_Data.BSSID, ap.BSSID);
-                rowData.put(WiFi_Data.SSID, ap.SSID);
+                rowData.put(WiFi_Data.BSSID, Encrypter.hashMac(mContext, ap.BSSID));
+                rowData.put(WiFi_Data.SSID, Encrypter.hashSsid(mContext, ap.SSID));
                 rowData.put(WiFi_Data.SECURITY, ap.capabilities);
                 rowData.put(WiFi_Data.FREQUENCY, ap.frequency);
                 rowData.put(WiFi_Data.RSSI, ap.level);

--- a/aware-core/src/main/java/com/aware/utils/Encrypter.java
+++ b/aware-core/src/main/java/com/aware/utils/Encrypter.java
@@ -77,12 +77,12 @@ public class Encrypter {
      * One-way string hashing using any algorithm
      * @param clear Text to be hashed
      * @param hash_function One of the allowed Android hash functions.  You sould be very sure
-     *                      that only a known hash_function is passed. (MD5, SHA-1, SHA-256,
-     *                      SHA-384, SHA-512).q
+     *                      that only a known hash_function is passed.
+     *                      (MD5, SHA-1, SHA-256, SHA-384, SHA-512).
      * @return String
      */
     public static final String hashGeneric(String clear, String hash_function) {
-        if( clear == null ) return "";
+        if( clear == null || clear.length() == 0 ) return "";
         try {
             // Create Hash
             MessageDigest digest = java.security.MessageDigest.getInstance(hash_function);
@@ -101,8 +101,66 @@ public class Encrypter {
 
         } catch (NoSuchAlgorithmException e) {
             e.printStackTrace();
+            return "<invalid alg "+hash_function+">";
         }
-        return "";
+    }
+
+    /*
+     * Run a hash program to hash data.  This not only does a hash, but can salt the cleartext,
+     * normalize the data, or apply other transformations.
+     *
+     * This looks up the settingName and runs it as a hash program.  It splits it by commas and
+     * runs these commands:
+     * - Anything not below: hash using that hash name (hashGeneric).  Ends processing.
+     * - "true": hash using the global HASH_FUNCTION and HASH_SALT.  Ends processing.
+     * - "clear": return the cleartext (default for some modes)
+     * - "salt=XXXX": salt using this value
+     * - "salt=device_id": salt using the device_id
+     * - "last=N": take only the last N digits
+     * - "normalize": Remove all non [0-9+] characters.
+     */
+    public static final String _hashProgram(Context context, String clear, String hashProgram) {
+        if( clear == null || clear.length() == 0  ) return "";
+
+        if (hashProgram.length() > 0) {
+            String[] hashProgramCommands = hashProgram.split(",");
+            for (String command: hashProgramCommands) {
+                if (command.equals("salt=device_id")) {
+                    // Salt using the device_id
+                    clear = clear + Aware.getSetting(context, Aware_Preferences.DEVICE_ID);
+                } else if (command.startsWith("salt=")) {
+                    // Salt using any string
+                    String[] command_split = command.split("=");
+                    // If salting with a empty hash, do nothing.
+                    if (command_split.length == 1) continue;
+                    clear = clear + command_split[1];
+                } else if (command.equals("normalize")) {
+                    // Remove all characters not in [0-9+]
+                    clear = clear.replaceAll("[^\\d+]", "");
+                } else if (command.equals("normalizeAlnum")) {
+                    // Remove all characters not in [0-9A-Za-z+]
+                    clear = clear.replaceAll("[^\\dA-Za-z+]", "");
+                } else if (command.startsWith("last=")) {
+                    // Take only the last N digits
+                    int start_idx = clear.length() - Integer.parseInt(command.split("=")[1]);
+                    if (start_idx < 0)
+                        start_idx = 0;
+                    clear = clear.substring(start_idx);
+                } else if (command.equals("clear")) {
+                    // Do not hash.  This is default for some modes.
+                    return clear;
+                } else if (command.equals("true")) {
+                    // Hash using global settings
+                    return hash(context, clear);
+                } else {
+                    // This is a hash algorithm name.  Hash it and return.  Stops loop.
+                    return hashGeneric(clear, command);
+                }
+            }
+        }
+        // Default: hash with default parameters (actually sets default parameters and calls
+        // this function again) if there are no
+        return hash(context, clear);
     }
 
     /**
@@ -110,76 +168,34 @@ public class Encrypter {
      * "hash_function") and calls the right hash.  It handles backwards compatibility:
      * defaults to SHA-1, and also defaults to SHA-1 if an invalid algorithm name is given.
      *
+     * This performs the default hashing.  The actual work is desegated to _hashProgram().
+     *
      * @param context Application context (for getting settings)
      * @param clear Text to be hashed
      * @return Hex-encoded hash
      */
     public static final String hash(Context context, String clear) {
-        if( clear == null ) return "";
-        String HASH_FUNCTION = Aware.getSetting(context.getApplicationContext(), Aware_Preferences.HASH_FUNCTION);
+        String hashProgram = Aware.getSetting(context.getApplicationContext(), Aware_Preferences.HASH_FUNCTION);
+        if (hashProgram.equals("")) {
+            // Default if unset
+            hashProgram = "SHA-1";
+        }
+
         String HASH_SALT = Aware.getSetting(context.getApplicationContext(), Aware_Preferences.HASH_SALT);
         // Option to salt per-device.
         if (HASH_SALT.equals("device_id"))
-            HASH_SALT = Aware.getSetting(context, Aware_Preferences.DEVICE_ID);
+            hashProgram = "salt=device_id," + hashProgram;
         // HASH_SALT defaults to empty
-        clear = clear + HASH_SALT;
-
-        // Go through and find our hash function, and apply it.  Handle defaults to SHA-1.
-        // Currently testing for each value individually to ensure a proper value is passed
-        // (or else exception raised)
-        if (HASH_FUNCTION.equals("")) {
-            // Default if unset
-            return hashSHA1(clear);
-        } else if (HASH_FUNCTION.equals("SHA-1")) {
-            return hashSHA1(clear);
-        } else if (HASH_FUNCTION.equals("SHA-256")) {
-            // Remember to be careful to only allow allowed names here.
-            return hashGeneric(clear, HASH_FUNCTION);
-        } else if (HASH_FUNCTION.equals("SHA-512")) {
-            return hashGeneric(clear, HASH_FUNCTION);
-        } else if (HASH_FUNCTION.equals("MD5")) {
-            return hashMD5(clear);
-        } else {
-            return hashGeneric(clear, "SHA-1");
-        }
+        hashProgram = "salt="+ HASH_SALT + "," + hashProgram;
+        return _hashProgram(context, clear, hashProgram);
     }
 
-    /**
-     * Hash a phone number.  This considers the setting "hash_function_phone" and can treat
-     * the number specially.  Options are "normalize": remove all characters except "+" and
-     * 0-9 from the number so that hashes can be compared.  "last6": only hashes the last six
-     * characters.  "salt_deviceid": Salt using our device_id.  Note that HASH_SALT is also
-     * applied!
-     *
-     * @param context Application context (for getting settings)
-     * @param clear Text to hash
-     * @return Hex-encoded hash
+    /*
+     * Hash a phone number.  Default to hashing even if blank.
      */
     public static final String hashPhone(Context context, String clear) {
-        String HASH_FUNCTION_PHONE = Aware.getSetting(context.getApplicationContext(), Aware_Preferences.HASH_FUNCTION_PHONE);
-
-        if (HASH_FUNCTION_PHONE.equals("normalize")) {
-            // Remove everything except 0-9 and "+"
-            clear = clear.replaceAll("[^\\d+]", "");
-            return hash(context, clear);
-        } else if (HASH_FUNCTION_PHONE.equals("last6")) {
-            // Hash only last six digits characters
-            clear = clear.replaceAll("[^\\d+]", "");
-            // Find the last six
-            int start_idx = clear.length() - 6;
-            if (start_idx < 0)
-                start_idx = 0;
-            clear = clear.substring(start_idx);
-            return hash(context, clear);
-        } else if (HASH_FUNCTION_PHONE.equals("salt_deviceid")) {
-            // Salt using our device ID.  Note that if HASH_SALT is also applied!
-            clear = clear.replaceAll("[^\\d+]", "");
-            clear = clear + Aware.getSetting(context, Aware_Preferences.DEVICE_ID);
-            return hash(context, clear);
-        }
-        else {
-            return hash(context, clear);
-        }
+        String hashProgram = Aware.getSetting(context.getApplicationContext(), Aware_Preferences.HASH_FUNCTION_PHONE);
+        return _hashProgram(context, clear, hashProgram);
     }
 
 

--- a/aware-core/src/main/java/com/aware/utils/Encrypter.java
+++ b/aware-core/src/main/java/com/aware/utils/Encrypter.java
@@ -198,6 +198,29 @@ public class Encrypter {
         return _hashProgram(context, clear, hashProgram);
     }
 
+    /*
+     * Hash a MAC address.  Defaults to not hashing.
+     */
+    public static final String hashMac(Context context, String clear) {
+        String hashProgram = Aware.getSetting(context.getApplicationContext(), Aware_Preferences.HASH_FUNCTION_MAC);
+        if (hashProgram.equals("")) {
+            hashProgram = "clear";
+        }
+        return _hashProgram(context, clear, hashProgram);
+    }
+
+    /*
+     * Hash a wifi/bluetooth SSID/name.  Defaults to not hashing.
+     */
+    public static final String hashSsid(Context context, String clear) {
+        String hashProgram = Aware.getSetting(context.getApplicationContext(), Aware_Preferences.HASH_FUNCTION_SSID);
+        if (hashProgram.equals("")) {
+            hashProgram = "clear";
+        }
+        return _hashProgram(context, clear, hashProgram);
+    }
+
+
 
     private static byte[] getRawKey(byte[] seed) throws Exception {
         KeyGenerator kgen = KeyGenerator.getInstance("AES");


### PR DESCRIPTION
I had previously made a more advanced method of hashing phone numbers, which could have different policies depending on how linkable or unlinkable you wanted things.

Now, I also need to hash network MACs/names, so instead of making more special cases, I introduced the concept of a hash program.  In the most basic sense, it just does a hash.  You can also specify normalization, salting (both with fixed seeds and with the device ID), taking the last N digits of a number, etc.  It may be a bit overkill, but I thought it better than copying and pasting and special-casing each thing that needs hashing.

Phone and default hashes run the same as before.  Now there are functions hashMac and hashSsid, which do what they say.  They default to returning the cleartext.  Config options are unchanged and everything is backwards compatible (except hashPhone, which does the same by default but I was probably the only one using it anyway.)

Can you think of more places that hashing should be used?  I could make a pass and document things more and add a more private mode.