### PR TITLE
Split some hardcoded options into a resources integers.xml file

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -570,7 +570,7 @@ public class Aware extends Service {
                     Scheduler.Schedule watchdog = Scheduler.getSchedule(this, SCHEDULE_KEEP_ALIVE);
                     if (watchdog == null) {
                         watchdog = new Scheduler.Schedule(SCHEDULE_KEEP_ALIVE);
-                        watchdog.setInterval(5)
+                        watchdog.setInterval(getApplicationContext().getResources().getInteger(R.integer.keep_alive_interval_min))
                                 .setActionType(Scheduler.ACTION_TYPE_SERVICE)
                                 .setActionIntentAction(ACTION_AWARE_KEEP_ALIVE)
                                 .setActionClass(getPackageName() + "/" + getClass().getName());
@@ -588,7 +588,7 @@ public class Aware extends Service {
                     Scheduler.Schedule compliance = Scheduler.getSchedule(this, Aware.SCHEDULE_STUDY_COMPLIANCE);
                     if (compliance == null) {
                         compliance = new Scheduler.Schedule(Aware.SCHEDULE_STUDY_COMPLIANCE);
-                        compliance.setInterval(10)
+                        compliance.setInterval(getResources().getInteger(R.integer.study_check_interval_min))
                                 .setActionType(Scheduler.ACTION_TYPE_SERVICE)
                                 .setActionIntentAction(Aware.ACTION_AWARE_STUDY_COMPLIANCE)
                                 .setActionClass(getPackageName() + "/" + getClass().getName());

--- a/aware-core/src/main/res/values/integers.xml
+++ b/aware-core/src/main/res/values/integers.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <item name="study_check_interval_min" type="integer" format="integer">10</item>
+    <item name="keep_alive_interval_min" type="integer" format="integer">5</item>
+</resources>


### PR DESCRIPTION
The study check and keepalive were hardcoded in the application.  This splits them into an integer resources file.  Useful for me because it makes it easier to keep my own branch's patches clean.

====
- default_study_check_interval_min
- keep_alive_interval_min
- These are hardcoded and would only be changed in specific branches