### PR TITLE
Put foreground notification text into res/values/strings.xml

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -296,14 +296,14 @@ public class Aware extends Service {
 
             NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(this);
             mBuilder.setSmallIcon(R.drawable.ic_action_aware_studies);
-            mBuilder.setContentText("AWARE is active.");
+            mBuilder.setContentText(getApplicationContext().getResources().getString(R.string.foreground_notification_text));
             mBuilder.setOngoing(true);
             mBuilder.setOnlyAlertOnce(true);
             mBuilder.setContentIntent(onTap);
             mBuilder.setDefaults(NotificationCompat.DEFAULT_ALL);
 
             if (isStudy(this)) {
-                mBuilder.addAction(R.drawable.ic_stat_aware_sync, "Sync", onSync);
+                mBuilder.addAction(R.drawable.ic_stat_aware_sync, getApplicationContext().getResources().getString(R.string.foreground_notification_sync_text), onSync);
             }
 
             startForeground(AWARE_FOREGROUND_SERVICE, mBuilder.build());

--- a/aware-core/src/main/res/values/strings.xml
+++ b/aware-core/src/main/res/values/strings.xml
@@ -22,4 +22,6 @@
     <string name="plugins_required">Plugins needed (install to join)</string>
     <string name="sign_up">Sign Up!</string>
     <string name="install">Install</string>
+    <string name="foreground_notification_text">AWARE is active.</string>
+    <string name="foreground_notification_sync_text">Sync</string>
 </resources>


### PR DESCRIPTION
Splitting out some of the new notification texts into strings.xml.  Again, this is useful to translate in my own branch for a study.  Perhaps I'll do more of these in the near future.

Would you be interested in a configuration option for a persistent notification?  I'm guessing this is to handle the latest API which is more aggressive in power saving?