### PR TITLE
isStudy: fix problem with advanced study URLs

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -487,7 +487,7 @@ public class Aware extends Service {
      * @return
      */
     public static Cursor getStudy(Context c, String study_url) {
-        return c.getContentResolver().query(Aware_Provider.Aware_Studies.CONTENT_URI, null, Aware_Provider.Aware_Studies.STUDY_URL + " LIKE '" + study_url + "'", null, Aware_Provider.Aware_Studies.STUDY_TIMESTAMP + " DESC LIMIT 1");
+        return c.getContentResolver().query(Aware_Provider.Aware_Studies.CONTENT_URI, null, Aware_Provider.Aware_Studies.STUDY_URL + " LIKE '" + study_url + "%'", null, Aware_Provider.Aware_Studies.STUDY_TIMESTAMP + " DESC LIMIT 1");
     }
 
     @Override

--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -453,7 +453,7 @@ public class Aware extends Service {
         boolean participant = false;
 
         Cursor study = c.getContentResolver().query(Aware_Provider.Aware_Studies.CONTENT_URI, null,
-                Aware_Provider.Aware_Studies.STUDY_URL + " LIKE '" + Aware.getSetting(c, Aware_Preferences.WEBSERVICE_SERVER) +
+                Aware_Provider.Aware_Studies.STUDY_URL + " LIKE '" + Aware.getSetting(c, Aware_Preferences.WEBSERVICE_SERVER) + "%" +
                         "' AND " + Aware_Provider.Aware_Studies.STUDY_JOINED + ">0" +
                         " AND " + Aware_Provider.Aware_Studies.STUDY_EXIT + "=0",
                 null, null);


### PR DESCRIPTION
- the study URL may have query parameters, while these are stripped
  when it is converted to a webservice URL.  This makes the "LIKE" no
  longer match.  This patch allows any query arguments (or extension) to the
  webservice URL.

(yes, there's an extra addition: I assume clarity is more important than conciseness)