### PR TITLE
Make scheduler wakeup interval configurable via resources

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -252,10 +252,11 @@ public class Aware extends Service {
         AlarmManager am = (AlarmManager) getSystemService(ALARM_SERVICE);
         Intent scheduler = new Intent(this, Scheduler.class);
         PendingIntent repeating = PendingIntent.getService(getApplicationContext(), 0, scheduler, PendingIntent.FLAG_UPDATE_CURRENT);
+        int wakeup_interval_ms = 60000 * getApplicationContext().getResources().getInteger(R.integer.alarm_wakeup_interval_min);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            am.setAlarmClock(new AlarmManager.AlarmClockInfo(System.currentTimeMillis() + (60000), repeating), repeating); //every minute
+            am.setAlarmClock(new AlarmManager.AlarmClockInfo(System.currentTimeMillis() + (wakeup_interval_ms), repeating), repeating); //every minute
         } else {
-            am.setRepeating(AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + 60000, 60000, repeating);
+            am.setRepeating(AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + wakeup_interval_ms, wakeup_interval_ms, repeating);
         }
 
         if (!Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {

--- a/aware-core/src/main/java/com/aware/utils/Scheduler.java
+++ b/aware-core/src/main/java/com/aware/utils/Scheduler.java
@@ -996,7 +996,8 @@ public class Scheduler extends Aware_Sensor {
                 AlarmManager am = (AlarmManager) getSystemService(ALARM_SERVICE);
                 Intent scheduler = new Intent(this, Scheduler.class);
                 PendingIntent repeating = PendingIntent.getService(getApplicationContext(), 0, scheduler, PendingIntent.FLAG_UPDATE_CURRENT);
-                am.setAlarmClock(new AlarmManager.AlarmClockInfo(System.currentTimeMillis() + (60000), repeating), repeating); //next minute
+                int wakeup_interval_ms = 60000 * getApplicationContext().getResources().getInteger(R.integer.alarm_wakeup_interval_min);
+                am.setAlarmClock(new AlarmManager.AlarmClockInfo(System.currentTimeMillis() + (wakeup_interval_ms), repeating), repeating); //next minute
             } else {
                 //no-op: using a repeating alarm for older versions of Android.
             }

--- a/aware-core/src/main/res/values/integers.xml
+++ b/aware-core/src/main/res/values/integers.xml
@@ -2,4 +2,5 @@
 <resources>
     <item name="study_check_interval_min" type="integer" format="integer">10</item>
     <item name="keep_alive_interval_min" type="integer" format="integer">5</item>
+    <item name="alarm_wakeup_interval_min" type="integer" format="integer">1</item>
 </resources>


### PR DESCRIPTION
- New integer resource: alarm_wakeup_interval_min.  Interval that
  schedule should tick.
- This allows researchers to trade off between battery usage and
  promptness of scheduler updates.  If it's increased, it may also
  encourage Android to put the app in a better battery usage class
  and treat it less badly
- Default remains the same: wakeup every minute.