### PR TITLE
Foreground notification

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -262,6 +262,7 @@ public class Aware extends Service {
         } else {
             IntentFilter scheduler = new IntentFilter();
             scheduler.addAction(Intent.ACTION_TIME_TICK);
+            schedulerTicker.interval_ms = 60000 * getApplicationContext().getResources().getInteger(R.integer.alarm_wakeup_interval_min);
             registerReceiver(schedulerTicker, scheduler);
         }
 
@@ -327,8 +328,8 @@ public class Aware extends Service {
 
     public class SchedulerTicker extends BroadcastReceiver {
         long last_time = 0;
-        // This is a static context, so we can't get the app resources here.  Hardcode for the
-        // time being.
+        // This is a static context, so we can't get the app resources here.  Set to the default
+        // here, and configure in Aware.onCreate.
         long interval_ms = 60000;
         @Override
         public void onReceive(Context context, Intent intent) {

--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -249,14 +249,20 @@ public class Aware extends Service {
         foreground.addAction(Aware.ACTION_AWARE_PRIORITY_BACKGROUND);
         registerReceiver(foregroundMgr, foreground);
 
-        AlarmManager am = (AlarmManager) getSystemService(ALARM_SERVICE);
-        Intent scheduler = new Intent(this, Scheduler.class);
-        PendingIntent repeating = PendingIntent.getService(getApplicationContext(), 0, scheduler, PendingIntent.FLAG_UPDATE_CURRENT);
-        int wakeup_interval_ms = 60000 * getApplicationContext().getResources().getInteger(R.integer.alarm_wakeup_interval_min);
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            am.setAlarmClock(new AlarmManager.AlarmClockInfo(System.currentTimeMillis() + (wakeup_interval_ms), repeating), repeating); //every minute
+        if (getApplicationContext().getResources().getBoolean(R.bool.alarmwakeup)) {
+            AlarmManager am = (AlarmManager) getSystemService(ALARM_SERVICE);
+            Intent scheduler = new Intent(this, Scheduler.class);
+            PendingIntent repeating = PendingIntent.getService(getApplicationContext(), 0, scheduler, PendingIntent.FLAG_UPDATE_CURRENT);
+            int wakeup_interval_ms = 60000 * getApplicationContext().getResources().getInteger(R.integer.alarm_wakeup_interval_min);
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                am.setAlarmClock(new AlarmManager.AlarmClockInfo(System.currentTimeMillis() + (wakeup_interval_ms), repeating), repeating); //every minute
+            } else {
+                am.setRepeating(AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + wakeup_interval_ms, wakeup_interval_ms, repeating);
+            }
         } else {
-            am.setRepeating(AlarmManager.RTC_WAKEUP, System.currentTimeMillis() + wakeup_interval_ms, wakeup_interval_ms, repeating);
+            IntentFilter scheduler = new IntentFilter();
+            scheduler.addAction(Intent.ACTION_TIME_TICK);
+            registerReceiver(schedulerTicker, scheduler);
         }
 
         if (!Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
@@ -314,6 +320,30 @@ public class Aware extends Service {
             startForeground(Aware.AWARE_FOREGROUND_SERVICE, not);
         } else {
             stopForeground(true);
+        }
+    }
+
+    private final SchedulerTicker schedulerTicker = new SchedulerTicker();
+
+    public class SchedulerTicker extends BroadcastReceiver {
+        long last_time = 0;
+        // This is a static context, so we can't get the app resources here.  Hardcode for the
+        // time being.
+        long interval_ms = 60000;
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            //Executed every 1-minute. OS will send this tickle automatically
+            if (intent.getAction().equals(Intent.ACTION_TIME_TICK)) {
+                long ts = System.currentTimeMillis();
+                // Subtract 30s.  The ticker only is every minute anyway, this gives us some
+                // slack in case the interval is slightly less than 60000ms.
+                if (ts > last_time + interval_ms - 30000) {
+                    last_time = ts;
+                    Intent scheduler = new Intent(context, Scheduler.class);
+                    scheduler.setAction(Scheduler.ACTION_AWARE_SCHEDULER_CHECK);
+                    context.startService(scheduler);
+                }
+            }
         }
     }
 
@@ -1742,6 +1772,9 @@ public class Aware extends Service {
             unregisterReceiver(storage_BR);
             unregisterReceiver(awareBoot);
             unregisterReceiver(foregroundMgr);
+            if (!getApplicationContext().getResources().getBoolean(R.bool.alarmwakeup)){
+                unregisterReceiver(schedulerTicker);
+            }
         } catch (IllegalArgumentException e) {
             //There is no API to check if a broadcast receiver already is registered. Since Aware.java is shared accross plugins, the receiver is only registered on the client, not the plugins.
         }

--- a/aware-core/src/main/java/com/aware/utils/Scheduler.java
+++ b/aware-core/src/main/java/com/aware/utils/Scheduler.java
@@ -1012,14 +1012,16 @@ public class Scheduler extends Aware_Sensor {
                 startService(aware);
             }
 
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                AlarmManager am = (AlarmManager) getSystemService(ALARM_SERVICE);
-                Intent scheduler = new Intent(this, Scheduler.class);
-                PendingIntent repeating = PendingIntent.getService(getApplicationContext(), 0, scheduler, PendingIntent.FLAG_UPDATE_CURRENT);
-                int wakeup_interval_ms = 60000 * getApplicationContext().getResources().getInteger(R.integer.alarm_wakeup_interval_min);
-                am.setAlarmClock(new AlarmManager.AlarmClockInfo(System.currentTimeMillis() + (wakeup_interval_ms), repeating), repeating); //next minute
-            } else {
-                //no-op: using a repeating alarm for older versions of Android.
+            if (getApplicationContext().getResources().getBoolean(R.bool.alarmwakeup)) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+                    AlarmManager am = (AlarmManager) getSystemService(ALARM_SERVICE);
+                    Intent scheduler = new Intent(this, Scheduler.class);
+                    PendingIntent repeating = PendingIntent.getService(getApplicationContext(), 0, scheduler, PendingIntent.FLAG_UPDATE_CURRENT);
+                    int wakeup_interval_ms = 60000 * getApplicationContext().getResources().getInteger(R.integer.alarm_wakeup_interval_min);
+                    am.setAlarmClock(new AlarmManager.AlarmClockInfo(System.currentTimeMillis() + (wakeup_interval_ms), repeating), repeating); //next minute
+                } else {
+                    //no-op: using a repeating alarm for older versions of Android.
+                }
             }
 
             DEBUG = Aware.getSetting(this, Aware_Preferences.DEBUG_FLAG).equals("true");

--- a/aware-core/src/main/res/values/bools.xml
+++ b/aware-core/src/main/res/values/bools.xml
@@ -3,4 +3,5 @@
     <item name="accessibility_access" type="bool" format="boolean">false</item>
     <item name="standalone" type="bool" format="boolean">false</item>
     <item name="internalstorage" type="bool" format="boolean">false</item>
+    <item name="alarmwakeup" type="bool" format="boolean">true</item>
 </resources>


### PR DESCRIPTION
This re-adds ability to use only a foreground notification, instead of the alarm wakeup.  You can see some notes in the commit messages.  This commit depends on #216.  You might want to wait until future messages before pulling this, for me to do more internal testing.  Advice is appreciated.

This will at least help me to minimize long-term diff.  I'm not sure if I'll keep this, but I'll do testing.  At least on 7 and below, it works well enough for my purposes - and alarm wakeup won't work for some of our studies.  I also aim to test if decreasing the wakeup interval will keep the app alive better (support is here but needs configurability).

I actually don't know if this patch is correct - does it look like it should work?