### PR TITLE
Fix: Start Aware from Scheduler in case is killed and there are no Ac…

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -264,6 +264,10 @@ public class Aware extends Service {
             return;
         }
 
+        // Start the foreground service only if it's the client or a standalone application
+        if ((getApplicationContext().getPackageName().equals("com.aware.phone") || getApplicationContext().getApplicationContext().getResources().getBoolean(R.bool.standalone)))
+            getApplicationContext().sendBroadcast(new Intent(Aware.ACTION_AWARE_PRIORITY_FOREGROUND));
+
         if (Aware.DEBUG) Log.d(TAG, "AWARE framework is created!");
     }
 

--- a/aware-core/src/main/java/com/aware/utils/Scheduler.java
+++ b/aware-core/src/main/java/com/aware/utils/Scheduler.java
@@ -1006,6 +1006,12 @@ public class Scheduler extends Aware_Sensor {
 
         if (PERMISSIONS_OK) {
 
+            //Restores core AWARE service in case it get's killed
+            if (!Aware.isServiceRunning(getApplicationContext(), Aware.class)) {
+                Intent aware = new Intent(getApplicationContext(), Aware.class);
+                startService(aware);
+            }
+
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
                 AlarmManager am = (AlarmManager) getSystemService(ALARM_SERVICE);
                 Intent scheduler = new Intent(this, Scheduler.class);


### PR DESCRIPTION
…cessibility events triggerd. Check if Aware should be a foreground service when starting