### PR TITLE
Schedule update

### DIFF
--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -1412,14 +1412,14 @@ public class Aware extends Service {
             }
         }
 
+        //Set schedulers
+        if (schedulers.length() > 0)
+            Scheduler.setSchedules(c, schedulers);
+
         if (config_changed) {
             ContentValues newCfg = new ContentValues();
             newCfg.put(Aware_Provider.Aware_Studies.STUDY_CONFIG, localConfig.toString());
             c.getContentResolver().update(Aware_Provider.Aware_Studies.CONTENT_URI, newCfg, Aware_Provider.Aware_Studies._ID + "=" + study_id, null);
-
-            //Set schedulers
-            if (schedulers.length() > 0)
-                Scheduler.setSchedules(c, schedulers);
 
             Intent aware = new Intent(c, Aware.class);
             c.startService(aware);

--- a/aware-core/src/main/java/com/aware/Aware.java
+++ b/aware-core/src/main/java/com/aware/Aware.java
@@ -457,7 +457,7 @@ public class Aware extends Service {
                     }
 
                     //Ignored by standalone apps. They handle their own sensors, so server settings do not apply.
-                    if (!getResources().getBoolean(R.bool.standalone)) {
+                    if (getPackageName().equals("com.aware.phone") || !getResources().getBoolean(R.bool.standalone)) {
                         if (study.getString("config").equalsIgnoreCase("[]")) {
                             Aware.tweakSettings(getApplicationContext(), new JSONArray(study.getString("config")));
                         } else if (!study.getString("config").equalsIgnoreCase("[]")) {


### PR DESCRIPTION
Hi,

I just remembered to make this PR about schedulers.  Aware should be able to update schedules from the study_check, but there were several things I encountered:

1) First, the necessary sync code only ran when it was not standalone, but `com.aware.phone` wasn't in that category.  Should this get the standard exception?

2) Second, the schedules were only updated when some other config changed.  This wasn't good in our case.

But don't merge yet!  This patch works and was tested in our latest study, but has certain assumptions.  If schedules are updated every time, the same schedule ID will be found and it will simply update the row in the database (this is what we used (actually server-side random questionnaires)).  But, if there are random questionnaires, then:

a) inserted at new random times.  Thus, more and more randoms will keep accumulating - not good.  My PR #212 is designed for this case.  If times are reproducible but still different each day, then they can be rescheduled and maintain the sampling.  This is because the same random time makes the same schedule ID.  (This is the same way my server does randoms).

b) random codepath unconditionally inserts, so will probably crash when schedule is updated.  This is easily fixable.

c) There's currently no way to delete existing schedules.  If random time changed, there would be duplicates for the next day.  This can just be ignored until it's a problem, since already deleting schedules is not supported.

What do you think?  Is the intention that schedules can be updated dynamically?  Do you think anything will break?  I can do some more updates to my two PRs to make things work, but my ability to test is limited now.

Thanks,

- Richard

