### PR TITLE
Make SchedulerTicker effective frequency configurable

### DIFF
--- a/aware-core/src/main/res/values/integers.xml
+++ b/aware-core/src/main/res/values/integers.xml
@@ -2,4 +2,5 @@
 <resources>
     <item name="study_check_interval_min" type="integer" format="integer">10</item>
     <item name="keep_alive_interval_min" type="integer" format="integer">30</item>
+    <item name="alarm_wakeup_interval_min" type="integer" format="integer">1</item>
 </resources>


### PR DESCRIPTION
This is the missing part of #217 I was talking about.  It lets you reduce the scheduler ticker interval to even less than 1 minute if you want to.  I found it useful because if you are only doing scheduler stuff, it can reduce the amount of processor and probably get better treatment from Android.  By default, no change from previous behavior.

----
- Android always ticks at 1-minute intervals (supposedly, but it can
  be anything).  This provides a switch to run the scheduler less
  often than this if you want.