### PR TITLE
Reduce amount of debugging

### DIFF
--- a/aware-core/src/main/java/com/aware/Accelerometer.java
+++ b/aware-core/src/main/java/com/aware/Accelerometer.java
@@ -134,7 +134,7 @@ public class Accelerometer extends Aware_Sensor implements SensorEventListener {
         accelData.putExtra(EXTRA_DATA, rowData);
         sendBroadcast(accelData);
 
-        if (Aware.DEBUG) Log.d(TAG, "Accelerometer: " + rowData.toString());
+        //if (Aware.DEBUG) Log.d(TAG, "Accelerometer: " + rowData.toString());
 
         if (data_values.size() < 250 && TS < LAST_SAVE + 300000) {
             return;

--- a/aware-core/src/main/java/com/aware/Barometer.java
+++ b/aware-core/src/main/java/com/aware/Barometer.java
@@ -120,7 +120,7 @@ public class Barometer extends Aware_Sensor implements SensorEventListener {
         pressureData.putExtra(EXTRA_DATA, rowData);
         sendBroadcast(pressureData);
 
-        if (Aware.DEBUG) Log.d(TAG, "Barometer:" + rowData.toString());
+        //if (Aware.DEBUG) Log.d(TAG, "Barometer:" + rowData.toString());
 
         if (data_values.size() < 250 && TS < LAST_SAVE + 300000) {
             return;

--- a/aware-core/src/main/java/com/aware/Gravity.java
+++ b/aware-core/src/main/java/com/aware/Gravity.java
@@ -142,7 +142,7 @@ public class Gravity extends Aware_Sensor implements SensorEventListener {
         gravityData.putExtra(EXTRA_DATA, rowData);
         sendBroadcast(gravityData);
 
-        if (Aware.DEBUG) Log.d(TAG, "Gravity:" + rowData.toString());
+        //if (Aware.DEBUG) Log.d(TAG, "Gravity:" + rowData.toString());
 
         if (data_values.size() < 250 && TS < LAST_SAVE + 300000) {
             return;

--- a/aware-core/src/main/java/com/aware/Gyroscope.java
+++ b/aware-core/src/main/java/com/aware/Gyroscope.java
@@ -143,7 +143,7 @@ public class Gyroscope extends Aware_Sensor implements SensorEventListener {
         gyroData.putExtra(EXTRA_DATA, rowData);
         sendBroadcast(gyroData);
 
-        if (Aware.DEBUG) Log.d(TAG, "Gyroscope:" + rowData.toString());
+        //if (Aware.DEBUG) Log.d(TAG, "Gyroscope:" + rowData.toString());
 
         if (data_values.size() < 250 && TS < LAST_SAVE + 300000) {
             return;

--- a/aware-core/src/main/java/com/aware/Light.java
+++ b/aware-core/src/main/java/com/aware/Light.java
@@ -123,7 +123,7 @@ public class Light extends Aware_Sensor implements SensorEventListener {
         lightData.putExtra(EXTRA_DATA, rowData);
         sendBroadcast(lightData);
 
-        if (Aware.DEBUG) Log.d(TAG, "Light:" + rowData.toString());
+        //if (Aware.DEBUG) Log.d(TAG, "Light:" + rowData.toString());
 
         if (data_values.size() < 250 && TS < LAST_SAVE + 300000) {
             return;

--- a/aware-core/src/main/java/com/aware/LinearAccelerometer.java
+++ b/aware-core/src/main/java/com/aware/LinearAccelerometer.java
@@ -140,7 +140,7 @@ public class LinearAccelerometer extends Aware_Sensor implements SensorEventList
         accelData.putExtra(EXTRA_DATA, rowData);
         sendBroadcast(accelData);
 
-        if (Aware.DEBUG) Log.d(TAG, "Linear-sync_accelerometer:" + rowData.toString());
+        //if (Aware.DEBUG) Log.d(TAG, "Linear-sync_accelerometer:" + rowData.toString());
 
         if (data_values.size() < 250 && TS < LAST_SAVE + 300000) {
             return;

--- a/aware-core/src/main/java/com/aware/Magnetometer.java
+++ b/aware-core/src/main/java/com/aware/Magnetometer.java
@@ -126,7 +126,7 @@ public class Magnetometer extends Aware_Sensor implements SensorEventListener {
         magnetoData.putExtra(EXTRA_DATA, rowData);
         sendBroadcast(magnetoData);
 
-        if (Aware.DEBUG) Log.d(TAG, "Magnetometer:" + rowData.toString());
+        //if (Aware.DEBUG) Log.d(TAG, "Magnetometer:" + rowData.toString());
 
         if (data_values.size() < 250 && TS < LAST_SAVE + 300000) {
             return;

--- a/aware-core/src/main/java/com/aware/Proximity.java
+++ b/aware-core/src/main/java/com/aware/Proximity.java
@@ -116,7 +116,7 @@ public class Proximity extends Aware_Sensor implements SensorEventListener {
         proxyData.putExtra(EXTRA_DATA, rowData);
         sendBroadcast(proxyData);
 
-        if (Aware.DEBUG) Log.d(TAG, "Proximity:" + rowData.toString());
+        //if (Aware.DEBUG) Log.d(TAG, "Proximity:" + rowData.toString());
 
         if (data_values.size() < 250 && TS < LAST_SAVE + 300000) {
             return;

--- a/aware-core/src/main/java/com/aware/Rotation.java
+++ b/aware-core/src/main/java/com/aware/Rotation.java
@@ -146,7 +146,7 @@ public class Rotation extends Aware_Sensor implements SensorEventListener {
         rotData.putExtra(EXTRA_DATA, rowData);
         sendBroadcast(rotData);
 
-        if (Aware.DEBUG) Log.d(TAG, "Rotation:" + rowData.toString());
+        //if (Aware.DEBUG) Log.d(TAG, "Rotation:" + rowData.toString());
 
         if (data_values.size() < 250 && TS < LAST_SAVE + 300000) {
             return;

--- a/aware-core/src/main/java/com/aware/Temperature.java
+++ b/aware-core/src/main/java/com/aware/Temperature.java
@@ -121,7 +121,7 @@ public class Temperature extends Aware_Sensor implements SensorEventListener {
         temperatureData.putExtra(EXTRA_DATA, rowData);
         sendBroadcast(temperatureData);
 
-        if (Aware.DEBUG) Log.d(TAG, "Temperature:" + rowData.toString());
+        //if (Aware.DEBUG) Log.d(TAG, "Temperature:" + rowData.toString());
 
         if (data_values.size() < 250 && TS < LAST_SAVE + 300000) {
             return;

--- a/aware-core/src/main/java/com/aware/utils/Scheduler.java
+++ b/aware-core/src/main/java/com/aware/utils/Scheduler.java
@@ -1170,7 +1170,7 @@ public class Scheduler extends Aware_Sensor {
             Log.i(TAG, "Time now is: " + now.getTime().toString());
 
             try {
-                Log.i(TAG, "Scheduler info: " + schedule.build().toString(5));
+                Log.i(TAG, "Scheduler info: id="+schedule.getScheduleID() +" schedule=" + schedule.build().toString());
             } catch (JSONException e) {
                 e.printStackTrace();
             }


### PR DESCRIPTION
This comments out some of the high-frequency sensor debuggings and makes scheduler output more compact.  I've found they clutter the logs and are not needed unless you are debugging that particular sensor, in which case I'd uncomment them.  I'm not sure if this should go upstream, but I figure better to make a PR than keep it to myself.  Just close if not desired.
---
- This should overall improve readability of logs
