### PR TITLE
BLE now follows the scan frequency

### DIFF
--- a/aware-core/src/main/java/com/aware/Bluetooth.java
+++ b/aware-core/src/main/java/com/aware/Bluetooth.java
@@ -242,28 +242,32 @@ public class Bluetooth extends Aware_Sensor {
         @Override
         public void run() {
             BluetoothLeScanner scanner = bluetoothAdapter.getBluetoothLeScanner();
-            if (scanner != null) {
-                if (isBLEScanning) {
-                    scanner.stopScan(scanCallback);
-                    if (awareSensor != null) awareSensor.onBLEScanEnded();
-                    if (Aware.DEBUG) Log.d(TAG, ACTION_AWARE_BLUETOOTH_BLE_SCAN_ENDED);
-                    Intent scanEnd = new Intent(ACTION_AWARE_BLUETOOTH_BLE_SCAN_ENDED);
-                    sendBroadcast(scanEnd);
-
-                    discoveredBLE.clear();
-
-                } else {
-                    scanner.startScan(null, scanSettings, scanCallback);
-                    if (awareSensor != null) awareSensor.onBLEScanStarted();
-                    if (Aware.DEBUG) Log.d(TAG, ACTION_AWARE_BLUETOOTH_BLE_SCAN_STARTED);
-                    Intent scanStart = new Intent(ACTION_AWARE_BLUETOOTH_BLE_SCAN_STARTED);
-                    sendBroadcast(scanStart);
-                }
-
+            if (scanner != null && !isBLEScanning) {
+                mBLEHandler.postDelayed(stopScan, 3000);
+                scanner.startScan(null, scanSettings, scanCallback);
+                if (awareSensor != null) awareSensor.onBLEScanStarted();
+                if (Aware.DEBUG) Log.d(TAG, ACTION_AWARE_BLUETOOTH_BLE_SCAN_STARTED);
+                Intent scanStart = new Intent(ACTION_AWARE_BLUETOOTH_BLE_SCAN_STARTED);
+                sendBroadcast(scanStart);
                 isBLEScanning = !isBLEScanning;
             }
-            //This will try again later if the scanner is null too.
-            mBLEHandler.postDelayed(this, Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_BLUETOOTH)) / 2 * 1000);
+        }
+    };
+
+    private Runnable stopScan = new Runnable() {
+        @Override
+        public void run() {
+            BluetoothLeScanner scanner = bluetoothAdapter.getBluetoothLeScanner();
+            if (scanner != null && isBLEScanning) {
+                mBLEHandler.postDelayed(scanRunnable, Integer.parseInt(Aware.getSetting(getApplicationContext(), Aware_Preferences.FREQUENCY_BLUETOOTH)) * 1000);
+                scanner.stopScan(scanCallback);
+                if (awareSensor != null) awareSensor.onBLEScanEnded();
+                if (Aware.DEBUG) Log.d(TAG, ACTION_AWARE_BLUETOOTH_BLE_SCAN_ENDED);
+                Intent scanEnd = new Intent(ACTION_AWARE_BLUETOOTH_BLE_SCAN_ENDED);
+                sendBroadcast(scanEnd);
+                discoveredBLE.clear();
+                isBLEScanning = !isBLEScanning;
+            }
         }
     };
 


### PR DESCRIPTION
- Uses callbacks to start and stop BLE scanning.

- Scan BLE devices for 3 seconds