### PR TITLE
webservice_simple: fix for transition to sync adapters

### DIFF
--- a/aware-core/src/main/java/com/aware/syncadapters/AwareSyncAdapter.java
+++ b/aware-core/src/main/java/com/aware/syncadapters/AwareSyncAdapter.java
@@ -381,6 +381,9 @@ public class AwareSyncAdapter extends AbstractThreadedSyncAdapter {
             } else {
                 latest = new Http().dataPOST(WEBSERVER + "/" + DATABASE_TABLE + "/latest", request, true);
             }
+        } else {
+            // Simplified API - no remote server contacting
+            latest = "[]";
         }
         return latest;
     }


### PR DESCRIPTION
Hi,

The transition to sync adapters made the webservice_simple flag (the one that always uploads all data, does not call /latest) not work, because `latest` was null.  This fixes it by setting it to `[]`, indicating "no most recent data" which causes Aware to upload all data, which is the desired behavior.

- Richard