### PR TITLE
Fix serverless sync

### DIFF
--- a/aware-core/src/main/java/com/aware/syncadapters/AwareSyncAdapter.java
+++ b/aware-core/src/main/java/com/aware/syncadapters/AwareSyncAdapter.java
@@ -376,7 +376,7 @@ public class AwareSyncAdapter extends AbstractThreadedSyncAdapter {
         String json_last_timestamp = null;
         long last_sync_timestamp;
 
-        Cursor lastSynched = mContext.getContentResolver().query(Aware_Provider.Aware_Log.CONTENT_URI, null, Aware_Provider.Aware_Log.LOG_MESSAGE + " LIKE '{\"table\":\"" + database_table + "\", \"last_sync_timestamp\":%'", null, Aware_Provider.Aware_Log.LOG_TIMESTAMP + " DESC LIMIT 1");
+        Cursor lastSynched = mContext.getContentResolver().query(Aware_Provider.Aware_Log.CONTENT_URI, null, Aware_Provider.Aware_Log.LOG_MESSAGE + " LIKE '{\"table\":\"" + database_table + "\",\"last_sync_timestamp\":%'", null, Aware_Provider.Aware_Log.LOG_TIMESTAMP + " DESC LIMIT 1");
 
         Log.d(Aware.TAG, DatabaseUtils.dumpCursorToString(lastSynched));
 

--- a/aware-core/src/main/java/com/aware/syncadapters/AwareSyncAdapter.java
+++ b/aware-core/src/main/java/com/aware/syncadapters/AwareSyncAdapter.java
@@ -12,6 +12,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SyncResult;
 import android.database.Cursor;
+import android.database.DatabaseUtils;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.net.Uri;
@@ -376,6 +377,9 @@ public class AwareSyncAdapter extends AbstractThreadedSyncAdapter {
         long last_sync_timestamp;
 
         Cursor lastSynched = mContext.getContentResolver().query(Aware_Provider.Aware_Log.CONTENT_URI, null, Aware_Provider.Aware_Log.LOG_MESSAGE + " LIKE '{\"table\":\"" + database_table + "\", \"last_sync_timestamp\":%'", null, Aware_Provider.Aware_Log.LOG_TIMESTAMP + " DESC LIMIT 1");
+
+        Log.d(Aware.TAG, DatabaseUtils.dumpCursorToString(lastSynched));
+
         if (lastSynched != null && lastSynched.moveToFirst()) {
             try {
                 JSONObject logSyncData = new JSONObject(lastSynched.getString(lastSynched.getColumnIndex(Aware_Provider.Aware_Log.LOG_MESSAGE)));

--- a/aware-core/src/main/java/com/aware/syncadapters/AwareSyncAdapter.java
+++ b/aware-core/src/main/java/com/aware/syncadapters/AwareSyncAdapter.java
@@ -461,7 +461,6 @@ public class AwareSyncAdapter extends AbstractThreadedSyncAdapter {
         if (latest == null) return 0;
 
         JSONArray remoteData = new JSONArray(latest);
-        Log.d(Aware.TAG, "Latest: " + remoteData.toString(5));
 
         int TOTAL_RECORDS = 0;
         if (remoteData.length() == 0) {

--- a/aware-core/src/main/java/com/aware/syncadapters/AwareSyncAdapter.java
+++ b/aware-core/src/main/java/com/aware/syncadapters/AwareSyncAdapter.java
@@ -185,8 +185,8 @@ public class AwareSyncAdapter extends AbstractThreadedSyncAdapter {
 
                     Log.d(Aware.TAG, "Table: " + database_table + " exists: " + (response != null && response.length() == 0));
                     Log.d(Aware.TAG, "Last synched record in this table: " + latest);
-                    if (study_condition.length() > 0) Log.d(Aware.TAG, "Joined study since: " + study_condition);
-                    if (total_records > 0) Log.d(Aware.TAG, "Rows to sync: " + total_records);
+                    Log.d(Aware.TAG, "Joined study since: " + study_condition);
+                    Log.d(Aware.TAG, "Rows remaining to sync: " + total_records);
                 }
 
                 // If we have records to sync
@@ -377,9 +377,6 @@ public class AwareSyncAdapter extends AbstractThreadedSyncAdapter {
         long last_sync_timestamp;
 
         Cursor lastSynched = mContext.getContentResolver().query(Aware_Provider.Aware_Log.CONTENT_URI, null, Aware_Provider.Aware_Log.LOG_MESSAGE + " LIKE '{\"table\":\"" + database_table + "\",\"last_sync_timestamp\":%'", null, Aware_Provider.Aware_Log.LOG_TIMESTAMP + " DESC LIMIT 1");
-
-        Log.d(Aware.TAG, DatabaseUtils.dumpCursorToString(lastSynched));
-
         if (lastSynched != null && lastSynched.moveToFirst()) {
             try {
                 JSONObject logSyncData = new JSONObject(lastSynched.getString(lastSynched.getColumnIndex(Aware_Provider.Aware_Log.LOG_MESSAGE)));
@@ -464,6 +461,7 @@ public class AwareSyncAdapter extends AbstractThreadedSyncAdapter {
         if (latest == null) return 0;
 
         JSONArray remoteData = new JSONArray(latest);
+        Log.d(Aware.TAG, "Latest: " + remoteData.toString(5));
 
         int TOTAL_RECORDS = 0;
         if (remoteData.length() == 0) {


### PR DESCRIPTION
- There was an extra space in the string used for the last timestamp query
- Improved debugging of the core by allowing us to know how many records are pending to sync for this sync batch.