### PR TITLE
* Created notification channels for android 8+ according to different…

### DIFF
--- a/aware-core/src/main/java/com/aware/Applications.java
+++ b/aware-core/src/main/java/com/aware/Applications.java
@@ -641,16 +641,16 @@ public class Applications extends AccessibilityService {
      */
     public synchronized static boolean isAccessibilityServiceActive(Context c) {
         if (!isAccessibilityEnabled(c)) {
-            NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(c, Aware.AWARE_NOTIFICATION_ID);
+            NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(c, Aware.AWARE_NOTIFICATION_CHANNEL_GENERAL);
             mBuilder.setSmallIcon(R.drawable.ic_stat_aware_accessibility);
             mBuilder.setContentTitle(c.getResources().getString(R.string.aware_activate_accessibility_title));
             mBuilder.setContentText(c.getResources().getString(R.string.aware_activate_accessibility));
             mBuilder.setAutoCancel(true);
             mBuilder.setOnlyAlertOnce(true); //notify the user only once
             mBuilder.setDefaults(NotificationCompat.DEFAULT_ALL);
-
+            mBuilder = Aware.setNotificationProperties(mBuilder, Aware.AWARE_NOTIFICATION_IMPORTANCE_GENERAL);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-                mBuilder.setChannelId(Aware.AWARE_NOTIFICATION_ID);
+                mBuilder.setChannelId(Aware.AWARE_NOTIFICATION_CHANNEL_GENERAL);
 
             Intent accessibilitySettings = new Intent(android.provider.Settings.ACTION_ACCESSIBILITY_SETTINGS);
             accessibilitySettings.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TOP);

--- a/aware-core/src/main/java/com/aware/Bluetooth.java
+++ b/aware-core/src/main/java/com/aware/Bluetooth.java
@@ -484,7 +484,7 @@ public class Bluetooth extends Aware_Sensor {
     private static void notifyMissingBluetooth(Context c, boolean dismiss) {
         if (!dismiss) {
             //Remind the user that we need Bluetooth on for data collection
-            NotificationCompat.Builder builder = new NotificationCompat.Builder(c, Aware.AWARE_NOTIFICATION_ID)
+            NotificationCompat.Builder builder = new NotificationCompat.Builder(c, Aware.AWARE_NOTIFICATION_CHANNEL_GENERAL)
                     .setSmallIcon(R.drawable.ic_stat_aware_accessibility)
                     .setContentTitle("AWARE: Bluetooth needed")
                     .setContentText("Tap to enable Bluetooth for nearby scanning.")
@@ -493,8 +493,10 @@ public class Bluetooth extends Aware_Sensor {
                     .setAutoCancel(true)
                     .setContentIntent(PendingIntent.getService(c, 123, enableBT, PendingIntent.FLAG_UPDATE_CURRENT));
 
+            builder = Aware.setNotificationProperties(builder, Aware.AWARE_NOTIFICATION_IMPORTANCE_GENERAL);
+
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-                builder.setChannelId(Aware.AWARE_NOTIFICATION_ID);
+                builder.setChannelId(Aware.AWARE_NOTIFICATION_CHANNEL_GENERAL);
 
             try {
                 notificationManager.notify(123, builder.build());

--- a/aware-core/src/main/java/com/aware/ESM.java
+++ b/aware-core/src/main/java/com/aware/ESM.java
@@ -442,7 +442,7 @@ public class ESM extends Aware_Sensor {
      */
     public static void notifyESM(Context context, boolean notifyOnce) {
 
-        NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context, Aware.AWARE_NOTIFICATION_ID);
+        NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context, Aware.AWARE_NOTIFICATION_CHANNEL_GENERAL);
         mBuilder.setSmallIcon(R.drawable.ic_stat_aware_esm);
         mBuilder.setContentTitle(context.getResources().getText(R.string.aware_esm_questions_title));
         mBuilder.setContentText(context.getResources().getText(R.string.aware_esm_questions));
@@ -451,9 +451,10 @@ public class ESM extends Aware_Sensor {
         mBuilder.setUsesChronometer(true);
         mBuilder.setOnlyAlertOnce(notifyOnce);
         mBuilder.setDefaults(NotificationCompat.DEFAULT_ALL);
+        mBuilder = Aware.setNotificationProperties(mBuilder, Aware.AWARE_NOTIFICATION_IMPORTANCE_GENERAL);
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-            mBuilder.setChannelId(Aware.AWARE_NOTIFICATION_ID);
+            mBuilder.setChannelId(Aware.AWARE_NOTIFICATION_CHANNEL_GENERAL);
 
         Intent intent_ESM = new Intent(context, ESM_Queue.class);
         intent_ESM.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/aware-core/src/main/java/com/aware/syncadapters/AwareSyncAdapter.java
+++ b/aware-core/src/main/java/com/aware/syncadapters/AwareSyncAdapter.java
@@ -221,7 +221,7 @@ public class AwareSyncAdapter extends AbstractThreadedSyncAdapter {
 
     private void notifyUser(Context mContext, String message, boolean dismiss, boolean indetermined, int id) {
         if (!dismiss) {
-            NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(mContext, Aware.AWARE_NOTIFICATION_ID);
+            NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(mContext, Aware.AWARE_NOTIFICATION_CHANNEL_DATASYNC);
             mBuilder.setSmallIcon(R.drawable.ic_stat_aware_sync);
             mBuilder.setContentTitle(mContext.getResources().getString(R.string.app_name));
             mBuilder.setContentText(message);
@@ -230,11 +230,13 @@ public class AwareSyncAdapter extends AbstractThreadedSyncAdapter {
             mBuilder.setDefaults(NotificationCompat.DEFAULT_LIGHTS); //we only blink the LED, nothing else.
             mBuilder.setProgress(100, 100, indetermined);
 
+            mBuilder = Aware.setNotificationProperties(mBuilder, Aware.AWARE_NOTIFICATION_IMPORTANCE_DATASYNC);
+
             PendingIntent clickIntent = PendingIntent.getActivity(mContext, 0, new Intent(), PendingIntent.FLAG_UPDATE_CURRENT);
             mBuilder.setContentIntent(clickIntent);
 
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-                mBuilder.setChannelId(Aware.AWARE_NOTIFICATION_ID);
+                mBuilder.setChannelId(Aware.AWARE_NOTIFICATION_CHANNEL_DATASYNC);
 
             try {
                 notManager.notify(id, mBuilder.build());
@@ -256,16 +258,16 @@ public class AwareSyncAdapter extends AbstractThreadedSyncAdapter {
         actManager.getMemoryInfo(memInfo);
 
         if (memInfo.lowMemory) {
-            NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(getContext(), Aware.AWARE_NOTIFICATION_ID);
+            NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(getContext(), Aware.AWARE_NOTIFICATION_CHANNEL_GENERAL);
             mBuilder.setSmallIcon(R.drawable.ic_stat_aware_plugin_dependency);
             mBuilder.setContentTitle("Low memory detected...");
             mBuilder.setContentText("Tap and swipe to clear recently used applications.");
             mBuilder.setAutoCancel(true);
             mBuilder.setOnlyAlertOnce(true);
             mBuilder.setDefaults(NotificationCompat.DEFAULT_ALL);
-
+            mBuilder = Aware.setNotificationProperties(mBuilder, Aware.AWARE_NOTIFICATION_IMPORTANCE_GENERAL);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-                mBuilder.setChannelId(Aware.AWARE_NOTIFICATION_ID);
+                mBuilder.setChannelId(Aware.AWARE_NOTIFICATION_CHANNEL_GENERAL);
 
             Intent intent = new Intent("com.android.systemui.recent.action.TOGGLE_RECENTS");
             intent.setComponent(new ComponentName("com.android.systemui", "com.android.systemui.recent.RecentsActivity"));

--- a/aware-core/src/main/java/com/aware/utils/DownloadPluginService.java
+++ b/aware-core/src/main/java/com/aware/utils/DownloadPluginService.java
@@ -93,15 +93,16 @@ public class DownloadPluginService extends IntentService {
 
                 String package_url = study_host + json_package.getString("package_path") + json_package.getString("package_name");
 
-                NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(getApplicationContext(), Aware.AWARE_NOTIFICATION_ID);
+                NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(getApplicationContext(), Aware.AWARE_NOTIFICATION_CHANNEL_DATASYNC);
                 mBuilder.setSmallIcon(R.drawable.ic_action_aware_plugins);
                 mBuilder.setContentTitle("AWARE Plugin");
                 mBuilder.setContentText(((is_update) ? "Updating " : "Downloading ") + json_package.getString("title"));
                 mBuilder.setProgress(0, 0, true);
                 mBuilder.setAutoCancel(true);
+                mBuilder = Aware.setNotificationProperties(mBuilder, Aware.AWARE_NOTIFICATION_IMPORTANCE_DATASYNC);
 
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O)
-                    mBuilder.setChannelId(Aware.AWARE_NOTIFICATION_ID);
+                    mBuilder.setChannelId(Aware.AWARE_NOTIFICATION_CHANNEL_DATASYNC);
 
                 final int notID = new Random(System.currentTimeMillis()).nextInt();
                 notManager.notify(notID, mBuilder.build());

--- a/aware-core/src/main/res/values/strings.xml
+++ b/aware-core/src/main/res/values/strings.xml
@@ -2,6 +2,11 @@
 <resources>
     <string name="app_name">AWARE</string>
     <string name="aware_description">AWARE is an Android\'s framework dedicated to infer, log and share mobile context information between mobile applications. Visit http://awareframework.com for details.</string>
+
+    <string name="channel_general_description">General AWARE notifications</string>
+    <string name="channel_silent_description">Non-interruptive AWARE notifications</string>
+    <string name="channel_datasync_description">AWARE datasync notifications</string>
+
     <string name="read_permission">Allow read-only access to the local data.</string>
     <string name="write_permission">Allow read and write access to the local data.</string>
     <string name="aware_studies">AWARE Studies</string>

--- a/aware-phone/src/main/java/com/aware/phone/Aware_Client.java
+++ b/aware-phone/src/main/java/com/aware/phone/Aware_Client.java
@@ -59,17 +59,6 @@ public class Aware_Client extends Aware_Activity implements SharedPreferences.On
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        //Android 8 specific: create a notification channel for AWARE
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationManager not_manager = (NotificationManager) getSystemService(NOTIFICATION_SERVICE);
-            NotificationChannel aware_channel = new NotificationChannel(Aware.AWARE_NOTIFICATION_ID, getResources().getString(R.string.app_name), NotificationManager.IMPORTANCE_DEFAULT);
-            aware_channel.setDescription(getResources().getString(R.string.aware_description));
-            aware_channel.enableLights(true);
-            aware_channel.setLightColor(Color.BLUE);
-            aware_channel.enableVibration(true);
-            not_manager.createNotificationChannel(aware_channel);
-        }
-
         prefs = getSharedPreferences("com.aware.phone", Context.MODE_PRIVATE);
         addPreferencesFromResource(R.xml.aware_preferences);
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         build_tools = "28.0.3"
         aware_libs = "master-SNAPSHOT"
         kotlin_version = "1.3.41"
-        build_gradle = "3.4.2"
+        build_gradle = '3.5.0'
         anko_version = "0.10.8"
     }
 
@@ -26,7 +26,7 @@ buildscript {
         maven { url "https://jitpack.io" }
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:$build_gradle"
+        classpath "com.android.tools.build:gradle:${build_gradle}"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Jun 11 16:05:50 EEST 2019
+#Thu Oct 03 15:15:49 EEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip


### PR DESCRIPTION
… requirements:

General - Aware.NOTIFICATION_CHANNEL_GENERAL: for any generic & important notifications that require end-user interaction, or at minimum require the user to observe the notification
Data sync - Aware.NOTIFICATION_CHANNEL_DATASYNC: For uploading & download (e.g., sync study data or download/update plugins).
Silent - Aware.NOTIFICATION_CHANNEL_SILENT: For any notifications that are only required to exist in background.

* Added a global function to set notification properties according to channel importance (for v7 or older devices):
Aware.setNotificationPreference(NotificationCompat builder, int notificationImportance)
- Use Aware.AWARE_NOTIFICATION_IMPORTANCE_GENERAL etc. as second variable to set importance according to the v8+ channel.

* Removed unused notification channel creation from aware-client onCreate(). All required channels are created in aware-core.

* Updated all notification functionalities to use new channels and set their properties accordingly.